### PR TITLE
Added injection token for map-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ import { AngularYandexMapsModule } from 'angular8-yandex-maps';
 export class AppModule { }
 ```
 
+### Configuration
 ##### Passing in your own map config options
 ```
 import { AngularYandexMapsModule, IConfig } from 'angular8-yandex-maps';
@@ -41,6 +42,25 @@ const mapConfig: IConfig = {
 
 @NgModule({
   imports: [AngularYandexMapsModule.forRoot(mapConfig)]
+})
+export class AppModule { }
+```
+
+##### Or use injection token
+```
+import { AngularYandexMapsModule, YA_MAP_CONFIG } from 'angular8-yandex-maps';
+
+@NgModule({
+  imports: [AngularYandexMapsModule],
+  providers: [
+  {
+      provide: YA_MAP_CONFIG,
+      useValue: {
+         apikey: 'API_KEY',
+         lang: 'en_US',
+      }
+    }
+  ]
 })
 export class AppModule { }
 ```

--- a/projects/angular8-yandex-maps/package.json
+++ b/projects/angular8-yandex-maps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular8-yandex-maps",
-  "version": "1.14.2",
+  "version": "1.14.3",
   "description": "Angular module for Yandex.Maps",
   "repository": {
     "type": "git",

--- a/projects/angular8-yandex-maps/src/lib/angular-yandex-maps.module.ts
+++ b/projects/angular8-yandex-maps/src/lib/angular-yandex-maps.module.ts
@@ -1,7 +1,7 @@
 import { ModuleWithProviders, NgModule } from '@angular/core';
 
 import { CommonModule } from '@angular/common';
-import { IConfig } from './models/models';
+import { IConfig, YA_MAP_CONFIG } from './models/models';
 import { YandexControlComponent } from './components/yandex-control-component/yandex-control.component';
 import { YandexGeoObjectComponent } from './components/yandex-geoobject-component/yandex-geoobject.component';
 import { YandexMapComponent } from './components/yandex-map-component/yandex-map.component';
@@ -39,7 +39,7 @@ export class AngularYandexMapsModule {
     return {
       ngModule: AngularYandexMapsModule,
       providers: [
-        { provide: 'CONFIG', useValue: config }
+        { provide: YA_MAP_CONFIG, useValue: config }
       ]
     };
   }

--- a/projects/angular8-yandex-maps/src/lib/models/models.ts
+++ b/projects/angular8-yandex-maps/src/lib/models/models.ts
@@ -2,6 +2,8 @@
  * Documentation for each property.
  * https://tech.yandex.ru/maps/jsapi/doc/2.1/dg/concepts/load-docpage/
  */
+import { InjectionToken } from "@angular/core";
+
 export interface IConfig {
   apikey: string;
   lang: 'ru_RU' | 'en_US' | 'en_RU' | 'ru_UA' | 'uk_UA' | 'tr_TR';
@@ -21,3 +23,5 @@ export interface IEvent {
   type: string | undefined;
   event: any;
 }
+
+export const YA_MAP_CONFIG = new InjectionToken<Partial<IConfig>>('YA_MAP_CONFIG');

--- a/projects/angular8-yandex-maps/src/lib/services/yandex-map/yandex-map.service.ts
+++ b/projects/angular8-yandex-maps/src/lib/services/yandex-map/yandex-map.service.ts
@@ -3,7 +3,7 @@ import { from, fromEvent, Observable } from 'rxjs';
 import { IYandexMapService } from './yandex-service.type';
 import { DOCUMENT } from '@angular/common';
 import { map, switchMap } from 'rxjs/operators';
-import { IConfig } from '../../models/models';
+import { IConfig, YA_MAP_CONFIG } from '../../models/models';
 
 declare const ymaps: any;
 
@@ -21,7 +21,7 @@ export class YandexMapService implements IYandexMapService {
   private _config: Partial<IConfig>;
 
   constructor(
-    @Optional() @Inject('CONFIG') config: Partial<IConfig>,
+    @Optional() @Inject(YA_MAP_CONFIG) config: Partial<IConfig>,
     @Inject(DOCUMENT) private document: Document
   ) {
     this._config = config || DEFAULT_CONFIG;


### PR DESCRIPTION
Sometimes the configuration needs to be defined in an implicit way, an injection token is required for this