### PR TITLE
feat: create all components outside an Angular zone

### DIFF
--- a/libs/angular-yandex-maps-v2/src/lib/components/ya-clusterer/ya-clusterer.component.ts
+++ b/libs/angular-yandex-maps-v2/src/lib/components/ya-clusterer/ya-clusterer.component.ts
@@ -176,14 +176,8 @@ export class YaClustererComponent implements AfterContentInit, OnChanges, OnDest
 
         const difference = this.getDifference<ymaps.Placemark>(newPlacemarks, currentPlacemarks);
 
-        /**
-         * Clusterer methods under the hood call setTimeout, as a result it triggers unexpected ticks.
-         * @see https://github.com/ddubrava/angular-yandex-maps/issues/194
-         */
-        this.ngZone.runOutsideAngular(() => {
-          clusterer.add(difference.toAdd);
-          clusterer.remove(difference.toRemove);
-        });
+        clusterer.add(difference.toAdd);
+        clusterer.remove(difference.toRemove);
       });
   }
 
@@ -203,14 +197,8 @@ export class YaClustererComponent implements AfterContentInit, OnChanges, OnDest
 
         const difference = this.getDifference<ymaps.GeoObject>(newGeoObjects, currentGeoObjects);
 
-        /**
-         * Clusterer methods under the hood call setTimeout, as a result it triggers unexpected ticks.
-         * @see https://github.com/ddubrava/angular-yandex-maps/issues/194
-         */
-        this.ngZone.runOutsideAngular(() => {
-          clusterer.add(difference.toAdd);
-          clusterer.remove(difference.toRemove);
-        });
+        clusterer.add(difference.toAdd);
+        clusterer.remove(difference.toRemove);
       });
   }
 

--- a/libs/angular-yandex-maps-v2/src/lib/services/ya-geocoder/ya-geocoder.service.ts
+++ b/libs/angular-yandex-maps-v2/src/lib/services/ya-geocoder/ya-geocoder.service.ts
@@ -2,6 +2,7 @@ import { Injectable, NgZone } from '@angular/core';
 import { from, Observable } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 
+import { enterZone } from '../../utils/zone/zone';
 import { YaApiLoaderService } from '../ya-api-loader/ya-api-loader.service';
 
 /**
@@ -38,15 +39,7 @@ export class YaGeocoderService {
   geocode(request: string | number[], options?: ymaps.IGeocodeOptions): Observable<object> {
     return this.yaApiLoaderService.load().pipe(
       switchMap(() => from(ymaps.geocode(request, options))),
-      switchMap(
-        (result) =>
-          new Observable<object>((observer) => {
-            this.ngZone.run(() => {
-              observer.next(result);
-              observer.complete();
-            });
-          }),
-      ),
+      enterZone(this.ngZone),
     );
   }
 }

--- a/libs/angular-yandex-maps-v2/src/lib/utils/zone/zone.ts
+++ b/libs/angular-yandex-maps-v2/src/lib/utils/zone/zone.ts
@@ -1,0 +1,24 @@
+/**
+ * Copied from Taiga UI.
+ * https://github.com/taiga-family/taiga-ui/blob/eafb4f498ff57f4a21eebe74aee97a72b5e8d3f8/projects/cdk/observables/zone.ts#L19
+ */
+
+import type { NgZone } from '@angular/core';
+import type { MonoTypeOperatorFunction } from 'rxjs';
+import { Observable } from 'rxjs';
+
+export function enterZone<T>(zone: NgZone): MonoTypeOperatorFunction<T> {
+  return (source) =>
+    new Observable((subscriber) =>
+      source.subscribe({
+        next: (value) => zone.run(() => subscriber.next(value)),
+        error: (error: unknown) => zone.run(() => subscriber.error(error)),
+        complete: () => zone.run(() => subscriber.complete()),
+      }),
+    );
+}
+
+export function exitZone<T>(zone: NgZone): MonoTypeOperatorFunction<T> {
+  return (source) =>
+    new Observable((subscriber) => zone.runOutsideAngular(() => source.subscribe(subscriber)));
+}

--- a/libs/angular-yandex-maps-v3/src/lib/components/common/y-map/y-map.component.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/common/y-map/y-map.component.ts
@@ -77,10 +77,7 @@ export class YMapComponent implements AfterViewInit, OnChanges, OnDestroy {
       .pipe(takeUntil(this.destroy$))
       .subscribe(() => {
         const id = generateRandomId();
-
-        // It must be outside a zone because it adds mouse listeners.
-        // As a result, there are tons of application ticks.
-        const map = this.ngZone.runOutsideAngular(() => this.createMap(id));
+        const map = this.createMap(id);
 
         /**
          * Once the configuration is changed, e.g. language,

--- a/libs/angular-yandex-maps-v3/src/lib/utils/zone/zone.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/utils/zone/zone.ts
@@ -1,0 +1,24 @@
+/**
+ * Copied from Taiga UI.
+ * https://github.com/taiga-family/taiga-ui/blob/eafb4f498ff57f4a21eebe74aee97a72b5e8d3f8/projects/cdk/observables/zone.ts#L19
+ */
+
+import type { NgZone } from '@angular/core';
+import type { MonoTypeOperatorFunction } from 'rxjs';
+import { Observable } from 'rxjs';
+
+export function enterZone<T>(zone: NgZone): MonoTypeOperatorFunction<T> {
+  return (source) =>
+    new Observable((subscriber) =>
+      source.subscribe({
+        next: (value) => zone.run(() => subscriber.next(value)),
+        error: (error: unknown) => zone.run(() => subscriber.error(error)),
+        complete: () => zone.run(() => subscriber.complete()),
+      }),
+    );
+}
+
+export function exitZone<T>(zone: NgZone): MonoTypeOperatorFunction<T> {
+  return (source) =>
+    new Observable((subscriber) => zone.runOutsideAngular(() => source.subscribe(subscriber)));
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring
- [ ] Build or CI related changes
- [ ] Documentation content changes

## Which library does this PR affect?

- [x] angular-yandex-maps-v2
- [x] angular-yandex-maps-v3

## What is the current behavior?

All third-party components must be outside an Angular zone because there is no reason to run them inside. The libraries mutate the DOM on their own, and they do not need ticks (change detections).

- In v2 `YaApiLoaderService` is implicitly outside a zone
- In v3 `YApiLoaderService` is in a zone, all components are also created in a zone

So we need to add `exitZone` explicitly to the services.

## What is the new behavior?

All components are created outside an Angular zone.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
