### PR TITLE
feat: support YMapFeatureDataSource component

### DIFF
--- a/libs/angular-yandex-maps-v3/src/index.ts
+++ b/libs/angular-yandex-maps-v3/src/index.ts
@@ -6,6 +6,7 @@
 export * from './lib/components/common/y-map/y-map.component';
 export * from './lib/components/common/y-map-default-marker/y-map-default-marker.directive';
 export * from './lib/components/common/y-map-feature/y-map-feature.directive';
+export * from './lib/components/common/y-map-feature-data-source/y-map-feature-data-source.directive';
 export * from './lib/components/common/y-map-listener/y-map-listener.directive';
 export * from './lib/components/common/y-map-marker/y-map-marker.directive';
 export * from './lib/components/controls/y-map-control/y-map-control.directive';

--- a/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-feature-data-source/y-map-feature-data-source.directive.spec.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-feature-data-source/y-map-feature-data-source.directive.spec.ts
@@ -1,0 +1,109 @@
+import { Component, ViewChild } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { YMapFeatureDataSourceProps } from '@yandex/ymaps3-types';
+import { BehaviorSubject } from 'rxjs';
+
+import {
+  mockYMapFeatureDataSourceConstructor,
+  mockYMapFeatureDataSourceInstance,
+  mockYMapInstance,
+} from '../../../../test-utils';
+import { YReadyEvent } from '../../../types/y-ready-event';
+import { YMapComponent } from '../y-map/y-map.component';
+import { YMapFeatureDataSourceDirective } from './y-map-feature-data-source.directive';
+
+@Component({
+  standalone: true,
+  imports: [YMapFeatureDataSourceDirective],
+  template: '<y-map-feature-data-source [props]="props" />',
+})
+class MockHostComponent {
+  @ViewChild(YMapFeatureDataSourceDirective, { static: true })
+  feature!: YMapFeatureDataSourceDirective;
+
+  props: YMapFeatureDataSourceProps = {
+    id: 'a-source',
+  };
+}
+
+describe('YMapFeatureDataSourceDirective', () => {
+  let component: YMapFeatureDataSourceDirective;
+  let mockComponent: MockHostComponent;
+  let fixture: ComponentFixture<MockHostComponent>;
+
+  let mapInstance: ReturnType<typeof mockYMapInstance>;
+  let sourceInstance: ReturnType<typeof mockYMapFeatureDataSourceInstance>;
+  let sourceConstructorMock: jest.Mock;
+
+  beforeEach(async () => {
+    mapInstance = mockYMapInstance();
+
+    await TestBed.configureTestingModule({
+      imports: [MockHostComponent],
+      providers: [
+        {
+          provide: YMapComponent,
+          useValue: {
+            map$: new BehaviorSubject(mapInstance),
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MockHostComponent);
+    mockComponent = fixture.componentInstance;
+    component = mockComponent.feature;
+
+    sourceInstance = mockYMapFeatureDataSourceInstance();
+    sourceConstructorMock = mockYMapFeatureDataSourceConstructor(sourceInstance);
+  });
+
+  afterEach(() => {
+    (window as any).ymaps3 = undefined;
+  });
+
+  it('should create entity', () => {
+    fixture.detectChanges();
+
+    expect(sourceConstructorMock).toHaveBeenCalledWith(mockComponent.props);
+    expect(mapInstance.addChild).toHaveBeenCalledWith(sourceInstance);
+  });
+
+  it('should emit ready on load', () => {
+    jest.spyOn(component.ready, 'emit');
+    fixture.detectChanges();
+
+    const readyEvent: YReadyEvent = {
+      ymaps3: (window as any).ymaps3,
+      entity: sourceInstance,
+    };
+
+    expect(component.ready.emit).toHaveBeenCalledWith(readyEvent);
+  });
+
+  it('should pass inputs to constructor', () => {
+    const props: YMapFeatureDataSourceProps = {
+      id: 'b-source',
+    };
+
+    mockComponent.props = props;
+
+    fixture.detectChanges();
+
+    expect(sourceConstructorMock).toHaveBeenCalledWith(props);
+  });
+
+  it('should update props input after init', () => {
+    fixture.detectChanges();
+
+    const props: YMapFeatureDataSourceProps = {
+      id: 'c-source',
+    };
+
+    mockComponent.props = props;
+
+    fixture.detectChanges();
+
+    expect(sourceInstance.update).toHaveBeenCalledWith(props);
+  });
+});

--- a/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-feature-data-source/y-map-feature-data-source.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-feature-data-source/y-map-feature-data-source.directive.ts
@@ -1,0 +1,77 @@
+import {
+  Directive,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  Output,
+  SimpleChanges,
+} from '@angular/core';
+import { YMapFeatureDataSource, YMapFeatureDataSourceProps } from '@yandex/ymaps3-types';
+import { Subject, takeUntil } from 'rxjs';
+import { filter } from 'rxjs/operators';
+
+import { YReadyEvent } from '../../../types/y-ready-event';
+import { YMapComponent } from '../y-map/y-map.component';
+
+/**
+ * This component wraps the [ymaps3.YMapFeatureDataSource](https://yandex.ru/dev/jsapi30/doc/ru/ref/#class-ymapfeaturedatasource) class from the Yandex.Maps API.
+ * All component inputs are named the same as the API class constructor arguments.
+ *
+ * ```html
+ * <y-map
+ *   [props]="{
+ *     location: {
+ *       center: [-0.127696, 51.507351],
+ *       zoom: 9,
+ *     },
+ *   }"
+ * >
+ *   <y-map-feature-data-source [props]="{ id: 'clusterer-source' }" />
+ * </y-map>
+ * ```
+ */
+@Directive({
+  selector: 'y-map-feature-data-source',
+  standalone: true,
+})
+export class YMapFeatureDataSourceDirective implements OnInit, OnDestroy, OnChanges {
+  private readonly destroy$ = new Subject<void>();
+
+  private source?: YMapFeatureDataSource;
+
+  /**
+   * See the API entity documentation for detailed information. Supports ngOnChanges.
+   * {@link https://yandex.ru/dev/jsapi30/doc/ru/ref/#YMapFeatureDataSourceProps}
+   */
+  @Input({ required: true }) props!: YMapFeatureDataSourceProps;
+
+  /**
+   * The entity instance is created. This event runs outside an Angular zone.
+   */
+  @Output() ready: EventEmitter<YReadyEvent<YMapFeatureDataSource>> = new EventEmitter<
+    YReadyEvent<YMapFeatureDataSource>
+  >();
+
+  constructor(private readonly yMapComponent: YMapComponent) {}
+
+  ngOnInit() {
+    this.yMapComponent.map$.pipe(filter(Boolean), takeUntil(this.destroy$)).subscribe((map) => {
+      this.source = new ymaps3.YMapFeatureDataSource(this.props);
+      map.addChild(this.source);
+      this.ready.emit({ ymaps3, entity: this.source });
+    });
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (this.source) {
+      this.source.update(changes['props'].currentValue);
+    }
+  }
+
+  ngOnDestroy() {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+}

--- a/libs/angular-yandex-maps-v3/src/test-utils.ts
+++ b/libs/angular-yandex-maps-v3/src/test-utils.ts
@@ -8,6 +8,7 @@ interface TestingWindow extends Window {
     YMapDefaultFeaturesLayer?: jest.Mock;
     YMapDefaultSchemeLayer?: jest.Mock;
     YMapFeature?: jest.Mock;
+    YMapFeatureDataSource?: jest.Mock;
     YMapGeolocationControl?: jest.Mock;
     YMapGroupEntity?: jest.Mock;
     YMapLayer?: jest.Mock;
@@ -524,6 +525,35 @@ export const mockYMapGroupEntityConstructor = (
   } else {
     testingWindow.ymaps3 = {
       YMapGroupEntity: constructorMock,
+    };
+  }
+
+  return constructorMock;
+};
+
+/**
+ * Mocks a ymaps3.YMapFeatureDataSource instance.
+ */
+export const mockYMapFeatureDataSourceInstance = () => ({
+  update: jest.fn(),
+});
+
+/**
+ * Mocks a ymaps3.YMapFeatureDataSource class.
+ * @param instance instance that is returned from a constructor.
+ */
+export const mockYMapFeatureDataSourceConstructor = (
+  instance: ReturnType<typeof mockYMapFeatureDataSourceInstance>,
+): jest.Mock => {
+  const constructorMock = jest.fn(() => instance);
+
+  const testingWindow: TestingWindow = window;
+
+  if (testingWindow.ymaps3) {
+    testingWindow.ymaps3.YMapFeatureDataSource = constructorMock;
+  } else {
+    testingWindow.ymaps3 = {
+      YMapFeatureDataSource: constructorMock,
     };
   }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

- [ ] Bugfix
- [X] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Documentation content changes

## Which library does this PR affect?

- [ ] angular-yandex-maps-v2
- [x] angular-yandex-maps-v3

## What is the current behavior?

`YMapFeatureDataSource ` is not supported

## What is the new behavior?

`YMapFeatureDataSource ` is supported

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
