### PR TITLE
fix: elementRef.nativeElement.firstChild is null after YMapMarker and YMapControl creation 

### DIFF
--- a/apps/angular-yandex-maps-v3-demo/src/app/app.component.html
+++ b/apps/angular-yandex-maps-v3-demo/src/app/app.component.html
@@ -39,6 +39,12 @@
         onClick: onMarkerClick,
       }"
     />
+
+    <y-map-marker [props]="{ coordinates: [-0.127696, 51.457351] }">
+      <div style="background-color: #fff; border-radius: 6px; padding: 3px 6px 4px">
+        {{ lang }}
+      </div>
+    </y-map-marker>
   </y-map>
 </div>
 
@@ -142,7 +148,7 @@
 
     <y-map-controls [props]="{ position: 'right' }">
       <y-map-control>
-        <p>Custom HTML</p>
+        <p>{{ lang }}</p>
       </y-map-control>
     </y-map-controls>
   </y-map>

--- a/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-marker/y-map-marker.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-marker/y-map-marker.directive.ts
@@ -58,6 +58,8 @@ export class YMapMarkerDirective implements AfterViewInit, OnDestroy, OnChanges 
 
   private marker?: YMapMarker;
 
+  private element?: HTMLElement;
+
   /**
    * See the API entity documentation for detailed information. Supports ngOnChanges.
    * {@link https://yandex.ru/dev/jsapi30/doc/ru/ref/#YMapMarkerProps}
@@ -88,9 +90,13 @@ export class YMapMarkerDirective implements AfterViewInit, OnDestroy, OnChanges 
       // We do not have any selectors, and we do not want to force users to use them.
       // All we need is an alternative to React children, just to get everything projected to the component.
       // Using an element reference is probably the easiest solution for this.
-      const element = this.elementRef.nativeElement.firstChild as HTMLElement;
+      if (!this.element) {
+        // It must be saved because the Yandex.Maps API deletes the element from the DOM.
+        // Therefore, after a configuration change, we pass null, since it's deleted.
+        this.element = this.elementRef.nativeElement.firstChild as HTMLElement;
+      }
 
-      this.marker = new ymaps3.YMapMarker(this.props, element);
+      this.marker = new ymaps3.YMapMarker(this.props, this.element);
       map.addChild(this.marker);
       this.ready.emit({ ymaps3, entity: this.marker });
     });


### PR DESCRIPTION
## What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Documentation content changes

## Which library does this PR affect?

- [ ] angular-yandex-maps-v2
- [x] angular-yandex-maps-v3

## What is the current behavior?

If we change a configuration, YMapMarker and YMapControl  become broken. The API removes them from the DOM, and after a configuration change, elementRef.nativeElement.firstChild is null

## What is the new behavior?

The element is saved to a separate variable, we pass it on a configuration change.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
