### PR TITLE
fix: fix redundant application ticks

### DIFF
--- a/libs/angular-yandex-maps-v2/src/lib/components/ya-clusterer/ya-clusterer.component.ts
+++ b/libs/angular-yandex-maps-v2/src/lib/components/ya-clusterer/ya-clusterer.component.ts
@@ -123,15 +123,18 @@ export class YaClustererComponent implements AfterContentInit, OnChanges, OnDest
    * @param changes
    */
   ngOnChanges(changes: SimpleChanges): void {
-    const { clusterer } = this;
+    // It must be run outside a zone; otherwise, all async events within this call will cause ticks.
+    this.ngZone.runOutsideAngular(() => {
+      const { clusterer } = this;
 
-    if (clusterer) {
-      const { options } = changes;
+      if (clusterer) {
+        const { options } = changes;
 
-      if (options) {
-        clusterer.options.set(options.currentValue);
+        if (options) {
+          clusterer.options.set(options.currentValue);
+        }
       }
-    }
+    });
   }
 
   ngAfterContentInit(): void {

--- a/libs/angular-yandex-maps-v2/src/lib/components/ya-geoobject/ya-geoobject.directive.ts
+++ b/libs/angular-yandex-maps-v2/src/lib/components/ya-geoobject/ya-geoobject.directive.ts
@@ -266,19 +266,22 @@ export class YaGeoObjectDirective implements OnInit, OnChanges, OnDestroy {
    * @param changes
    */
   ngOnChanges(changes: SimpleChanges): void {
-    const { geoObject } = this;
+    // It must be run outside a zone; otherwise, all async events within this call will cause ticks.
+    this.ngZone.runOutsideAngular(() => {
+      const { geoObject } = this;
 
-    if (geoObject) {
-      const { feature, options } = changes;
+      if (geoObject) {
+        const { feature, options } = changes;
 
-      if (feature) {
-        this.setFeature(feature.currentValue, geoObject);
+        if (feature) {
+          this.setFeature(feature.currentValue, geoObject);
+        }
+
+        if (options) {
+          geoObject.options.set(options.currentValue);
+        }
       }
-
-      if (options) {
-        geoObject.options.set(options.currentValue);
-      }
-    }
+    });
   }
 
   ngOnInit(): void {

--- a/libs/angular-yandex-maps-v2/src/lib/components/ya-map/ya-map.component.ts
+++ b/libs/angular-yandex-maps-v2/src/lib/components/ya-map/ya-map.component.ts
@@ -275,27 +275,30 @@ export class YaMapComponent implements AfterViewInit, OnChanges, OnDestroy {
    * @param changes
    */
   ngOnChanges(changes: SimpleChanges): void {
-    const map = this.map$.value;
+    // It must be run outside a zone; otherwise, all async events within this call will cause ticks.
+    this.ngZone.runOutsideAngular(() => {
+      const map = this.map$.value;
 
-    if (map) {
-      const { center, zoom, state, options } = changes;
+      if (map) {
+        const { center, zoom, state, options } = changes;
 
-      if (state) {
-        this.setState(this.combineState(), map);
+        if (state) {
+          this.setState(this.combineState(), map);
+        }
+
+        if (center) {
+          map.setCenter(center.currentValue);
+        }
+
+        if (zoom) {
+          map.setZoom(zoom.currentValue);
+        }
+
+        if (options) {
+          map.options.set(options.currentValue);
+        }
       }
-
-      if (center) {
-        map.setCenter(center.currentValue);
-      }
-
-      if (zoom) {
-        map.setZoom(zoom.currentValue);
-      }
-
-      if (options) {
-        map.options.set(options.currentValue);
-      }
-    }
+    });
   }
 
   ngAfterViewInit(): void {

--- a/libs/angular-yandex-maps-v2/src/lib/components/ya-multiroute/ya-multiroute.directive.ts
+++ b/libs/angular-yandex-maps-v2/src/lib/components/ya-multiroute/ya-multiroute.directive.ts
@@ -259,23 +259,26 @@ export class YaMultirouteDirective implements OnInit, OnChanges, OnDestroy {
    * @param changes
    */
   ngOnChanges(changes: SimpleChanges): void {
-    const { multiroute } = this;
+    // It must be run outside a zone; otherwise, all async events within this call will cause ticks.
+    this.ngZone.runOutsideAngular(() => {
+      const { multiroute } = this;
 
-    if (multiroute) {
-      const { referencePoints, model, options } = changes;
+      if (multiroute) {
+        const { referencePoints, model, options } = changes;
 
-      if (model) {
-        this.setModel(model.currentValue, multiroute);
+        if (model) {
+          this.setModel(model.currentValue, multiroute);
+        }
+
+        if (referencePoints) {
+          multiroute.model.setReferencePoints(referencePoints.currentValue);
+        }
+
+        if (options) {
+          multiroute.options.set(options.currentValue);
+        }
       }
-
-      if (referencePoints) {
-        multiroute.model.setReferencePoints(referencePoints.currentValue);
-      }
-
-      if (options) {
-        multiroute.options.set(options.currentValue);
-      }
-    }
+    });
   }
 
   ngOnInit(): void {

--- a/libs/angular-yandex-maps-v2/src/lib/components/ya-object-manager/ya-object-manager.directive.ts
+++ b/libs/angular-yandex-maps-v2/src/lib/components/ya-object-manager/ya-object-manager.directive.ts
@@ -192,15 +192,18 @@ export class YaObjectManagerDirective implements OnInit, OnChanges, OnDestroy {
    * @param changes
    */
   ngOnChanges(changes: SimpleChanges): void {
-    const { objectManager } = this;
+    // It must be run outside a zone; otherwise, all async events within this call will cause ticks.
+    this.ngZone.runOutsideAngular(() => {
+      const { objectManager } = this;
 
-    if (objectManager) {
-      const { options } = changes;
+      if (objectManager) {
+        const { options } = changes;
 
-      if (options) {
-        objectManager.options.set(options.currentValue);
+        if (options) {
+          objectManager.options.set(options.currentValue);
+        }
       }
-    }
+    });
   }
 
   ngOnInit(): void {

--- a/libs/angular-yandex-maps-v2/src/lib/components/ya-panorama/ya-panorama.directive.ts
+++ b/libs/angular-yandex-maps-v2/src/lib/components/ya-panorama/ya-panorama.directive.ts
@@ -150,27 +150,30 @@ export class YaPanoramaDirective implements OnInit, OnChanges, OnDestroy {
    * @param changes
    */
   ngOnChanges(changes: SimpleChanges): void {
-    const { player } = this;
+    // It must be run outside a zone; otherwise, all async events within this call will cause ticks.
+    this.ngZone.runOutsideAngular(() => {
+      const { player } = this;
 
-    if (player) {
-      const { point, layer, options } = changes;
+      if (player) {
+        const { point, layer, options } = changes;
 
-      /**
-       * player.moveTo resets values to default if any of them isn't passed.
-       * That's why we use value from currentValue OR previous value from input.
-       * With that logic it's possible to pass only point, layer or options.
-       */
-      if (point || layer) {
-        const combinedPoint: number[] = point?.currentValue || this.point;
-        const combinedLayer: ymaps.panorama.Layer = layer?.currentValue || this.layer;
+        /**
+         * player.moveTo resets values to default if any of them isn't passed.
+         * That's why we use value from currentValue OR previous value from input.
+         * With that logic it's possible to pass only point, layer or options.
+         */
+        if (point || layer) {
+          const combinedPoint: number[] = point?.currentValue || this.point;
+          const combinedLayer: ymaps.panorama.Layer = layer?.currentValue || this.layer;
 
-        player.moveTo(combinedPoint, { layer: combinedLayer });
+          player.moveTo(combinedPoint, { layer: combinedLayer });
+        }
+
+        if (options) {
+          this.setOptions(options.currentValue, player);
+        }
       }
-
-      if (options) {
-        this.setOptions(options.currentValue, player);
-      }
-    }
+    });
   }
 
   ngOnInit(): void {

--- a/libs/angular-yandex-maps-v2/src/lib/components/ya-placemark/ya-placemark.directive.ts
+++ b/libs/angular-yandex-maps-v2/src/lib/components/ya-placemark/ya-placemark.directive.ts
@@ -270,23 +270,26 @@ export class YaPlacemarkDirective implements OnInit, OnChanges, OnDestroy {
    * @param changes
    */
   ngOnChanges(changes: SimpleChanges): void {
-    const { placemark } = this;
+    // It must be run outside a zone; otherwise, all async events within this call will cause ticks.
+    this.ngZone.runOutsideAngular(() => {
+      const { placemark } = this;
 
-    if (placemark) {
-      const { geometry, properties, options } = changes;
+      if (placemark) {
+        const { geometry, properties, options } = changes;
 
-      if (geometry) {
-        placemark.geometry?.setCoordinates(geometry.currentValue);
+        if (geometry) {
+          placemark.geometry?.setCoordinates(geometry.currentValue);
+        }
+
+        if (properties) {
+          placemark.properties.set(properties.currentValue);
+        }
+
+        if (options) {
+          placemark.options.set(options.currentValue);
+        }
       }
-
-      if (properties) {
-        placemark.properties.set(properties.currentValue);
-      }
-
-      if (options) {
-        placemark.options.set(options.currentValue);
-      }
-    }
+    });
   }
 
   ngOnInit(): void {

--- a/libs/angular-yandex-maps-v2/src/lib/services/ya-api-loader/ya-api-loader.service.ts
+++ b/libs/angular-yandex-maps-v2/src/lib/services/ya-api-loader/ya-api-loader.service.ts
@@ -109,6 +109,9 @@ export class YaApiLoaderService {
            * we can return of(window.ymaps), but calling ready is safer, I believe.
            */
           return from(apiObject.ready()).pipe(
+            // Each nested operator should run outside the zone.
+            // Refer to the comment above for the reason why we need to exit the zone.
+            exitZone(this.ngZone),
             /**
              * Actually, we need to update it only if they are not equal,
              * it happens if we change the configuration which required new window.ymaps.
@@ -150,7 +153,12 @@ export class YaApiLoaderService {
 
         const error = fromEvent(script, 'error').pipe(switchMap(throwError));
 
-        return merge(load, error).pipe(take(1));
+        return merge(load, error).pipe(
+          // Each nested operator should run outside the zone.
+          // Refer to the comment above for the reason why we need to exit the zone.
+          exitZone(this.ngZone),
+          take(1),
+        );
       }),
     );
   }

--- a/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-default-marker/y-map-default-marker.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-default-marker/y-map-default-marker.directive.ts
@@ -2,6 +2,7 @@ import {
   Directive,
   EventEmitter,
   Input,
+  NgZone,
   OnChanges,
   OnDestroy,
   OnInit,
@@ -65,7 +66,10 @@ export class YMapDefaultMarkerDirective implements OnInit, OnDestroy, OnChanges 
     YReadyEvent<YMapDefaultMarker>
   >();
 
-  constructor(private readonly yMapComponent: YMapComponent) {}
+  constructor(
+    private readonly ngZone: NgZone,
+    private readonly yMapComponent: YMapComponent,
+  ) {}
 
   ngOnInit() {
     this.yMapComponent.map$
@@ -87,9 +91,12 @@ export class YMapDefaultMarkerDirective implements OnInit, OnDestroy, OnChanges 
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    if (this.marker) {
-      this.marker.update(changes['props'].currentValue);
-    }
+    // It must be run outside a zone; otherwise, all async events within this call will cause ticks.
+    this.ngZone.runOutsideAngular(() => {
+      if (this.marker) {
+        this.marker.update(changes['props'].currentValue);
+      }
+    });
   }
 
   ngOnDestroy() {

--- a/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-hint/y-map-hint.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-hint/y-map-hint.directive.ts
@@ -4,6 +4,7 @@ import {
   Directive,
   EventEmitter,
   Input,
+  NgZone,
   OnChanges,
   OnDestroy,
   Output,
@@ -96,7 +97,10 @@ export class YMapHintDirective implements AfterContentInit, OnChanges, OnDestroy
    */
   @Output() ready: EventEmitter<YReadyEvent<YMapHint>> = new EventEmitter<YReadyEvent<YMapHint>>();
 
-  constructor(private readonly yMapComponent: YMapComponent) {}
+  constructor(
+    private readonly ngZone: NgZone,
+    private readonly yMapComponent: YMapComponent,
+  ) {}
 
   ngAfterContentInit() {
     this.yMapComponent.map$
@@ -125,9 +129,12 @@ export class YMapHintDirective implements AfterContentInit, OnChanges, OnDestroy
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    if (this.hint) {
-      this.hint.update(changes['props'].currentValue);
-    }
+    // It must be run outside a zone; otherwise, all async events within this call will cause ticks.
+    this.ngZone.runOutsideAngular(() => {
+      if (this.hint) {
+        this.hint.update(changes['props'].currentValue);
+      }
+    });
   }
 
   ngOnDestroy() {

--- a/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-listener/y-map-listener.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-listener/y-map-listener.directive.ts
@@ -1,8 +1,8 @@
 import {
   Directive,
-  ElementRef,
   EventEmitter,
   Input,
+  NgZone,
   OnChanges,
   OnDestroy,
   OnInit,
@@ -62,7 +62,7 @@ export class YMapListenerDirective implements OnInit, OnChanges, OnDestroy {
   >();
 
   constructor(
-    private readonly elementRef: ElementRef<HTMLElement>,
+    private readonly ngZone: NgZone,
     private readonly yMapComponent: YMapComponent,
   ) {}
 
@@ -75,9 +75,12 @@ export class YMapListenerDirective implements OnInit, OnChanges, OnDestroy {
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    if (this.listener) {
-      this.listener.update(changes['props'].currentValue);
-    }
+    // It must be run outside a zone; otherwise, all async events within this call will cause ticks.
+    this.ngZone.runOutsideAngular(() => {
+      if (this.listener) {
+        this.listener.update(changes['props'].currentValue);
+      }
+    });
   }
 
   ngOnDestroy() {

--- a/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-marker/y-map-marker.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-marker/y-map-marker.directive.ts
@@ -4,6 +4,7 @@ import {
   ElementRef,
   EventEmitter,
   Input,
+  NgZone,
   OnChanges,
   OnDestroy,
   Output,
@@ -74,14 +75,18 @@ export class YMapMarkerDirective implements AfterViewInit, OnDestroy, OnChanges 
   >();
 
   constructor(
+    private readonly ngZone: NgZone,
     private readonly elementRef: ElementRef<HTMLElement>,
     private readonly yMapComponent: YMapComponent,
   ) {}
 
   ngOnChanges(changes: SimpleChanges) {
-    if (this.marker) {
-      this.marker.update(changes['props'].currentValue);
-    }
+    // It must be run outside a zone; otherwise, all async events within this call will cause ticks.
+    this.ngZone.runOutsideAngular(() => {
+      if (this.marker) {
+        this.marker.update(changes['props'].currentValue);
+      }
+    });
   }
 
   ngAfterViewInit() {

--- a/libs/angular-yandex-maps-v3/src/lib/components/common/y-map/y-map.component.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/common/y-map/y-map.component.ts
@@ -93,9 +93,12 @@ export class YMapComponent implements AfterViewInit, OnChanges, OnDestroy {
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    if (this.map$.value) {
-      this.map$.value.update(changes['props'].currentValue);
-    }
+    // It must be run outside a zone; otherwise, all async events within this call will cause ticks.
+    this.ngZone.runOutsideAngular(() => {
+      if (this.map$.value) {
+        this.map$.value.update(changes['props'].currentValue);
+      }
+    });
   }
 
   ngOnDestroy() {

--- a/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-control-button/y-map-control-button.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-control-button/y-map-control-button.directive.ts
@@ -2,6 +2,7 @@ import {
   Directive,
   EventEmitter,
   Input,
+  NgZone,
   OnChanges,
   OnDestroy,
   OnInit,
@@ -65,7 +66,10 @@ export class YMapControlButtonDirective implements OnInit, OnChanges, OnDestroy 
     YReadyEvent<YMapControlButton>
   >();
 
-  constructor(private readonly yMapControlsDirective: YMapControlsDirective) {}
+  constructor(
+    private readonly ngZone: NgZone,
+    private readonly yMapControlsDirective: YMapControlsDirective,
+  ) {}
 
   ngOnInit() {
     this.yMapControlsDirective.controls$
@@ -78,9 +82,12 @@ export class YMapControlButtonDirective implements OnInit, OnChanges, OnDestroy 
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    if (this.control) {
-      this.control.update(changes['props'].currentValue);
-    }
+    // It must be run outside a zone; otherwise, all async events within this call will cause ticks.
+    this.ngZone.runOutsideAngular(() => {
+      if (this.control) {
+        this.control.update(changes['props'].currentValue);
+      }
+    });
   }
 
   ngOnDestroy() {

--- a/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-control-common-button/y-map-control-common-button.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-control-common-button/y-map-control-common-button.directive.ts
@@ -2,6 +2,7 @@ import {
   Directive,
   EventEmitter,
   Input,
+  NgZone,
   OnChanges,
   OnDestroy,
   OnInit,
@@ -68,7 +69,10 @@ export class YMapControlCommonButtonDirective implements OnInit, OnChanges, OnDe
     YReadyEvent<YMapControlCommonButton>
   >();
 
-  constructor(private readonly yMapControlsDirective: YMapControlsDirective) {}
+  constructor(
+    private readonly ngZone: NgZone,
+    private readonly yMapControlsDirective: YMapControlsDirective,
+  ) {}
 
   ngOnInit() {
     this.yMapControlsDirective.controls$
@@ -81,9 +85,12 @@ export class YMapControlCommonButtonDirective implements OnInit, OnChanges, OnDe
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    if (this.control) {
-      this.control.update(changes['props'].currentValue);
-    }
+    // It must be run outside a zone; otherwise, all async events within this call will cause ticks.
+    this.ngZone.runOutsideAngular(() => {
+      if (this.control) {
+        this.control.update(changes['props'].currentValue);
+      }
+    });
   }
 
   ngOnDestroy() {

--- a/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-control/y-map-control.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-control/y-map-control.directive.ts
@@ -67,6 +67,7 @@ export class YMapControlDirective implements AfterViewInit, OnChanges, OnDestroy
   >();
 
   constructor(
+    private readonly ngZone: NgZone,
     private readonly elementRef: ElementRef<HTMLElement>,
     private readonly yMapControlsDirective: YMapControlsDirective,
   ) {}
@@ -93,9 +94,12 @@ export class YMapControlDirective implements AfterViewInit, OnChanges, OnDestroy
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    if (this.control) {
-      this.control.update(changes['props'].currentValue);
-    }
+    // It must be run outside a zone; otherwise, all async events within this call will cause ticks.
+    this.ngZone.runOutsideAngular(() => {
+      if (this.control) {
+        this.control.update(changes['props'].currentValue);
+      }
+    });
   }
 
   ngOnDestroy() {

--- a/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-geolocation-control/y-map-geolocation-control.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-geolocation-control/y-map-geolocation-control.directive.ts
@@ -2,6 +2,7 @@ import {
   Directive,
   EventEmitter,
   Input,
+  NgZone,
   OnChanges,
   OnDestroy,
   OnInit,
@@ -62,7 +63,10 @@ export class YMapGeolocationControlDirective implements OnInit, OnChanges, OnDes
     YReadyEvent<YMapGeolocationControl>
   >();
 
-  constructor(private readonly yMapControlsDirective: YMapControlsDirective) {}
+  constructor(
+    private readonly ngZone: NgZone,
+    private readonly yMapControlsDirective: YMapControlsDirective,
+  ) {}
 
   ngOnInit() {
     this.yMapControlsDirective.controls$
@@ -84,9 +88,12 @@ export class YMapGeolocationControlDirective implements OnInit, OnChanges, OnDes
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    if (this.control) {
-      this.control.update(changes['props'].currentValue);
-    }
+    // It must be run outside a zone; otherwise, all async events within this call will cause ticks.
+    this.ngZone.runOutsideAngular(() => {
+      if (this.control) {
+        this.control.update(changes['props'].currentValue);
+      }
+    });
   }
 
   ngOnDestroy() {

--- a/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-open-maps-button/y-map-open-maps-button.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-open-maps-button/y-map-open-maps-button.directive.ts
@@ -2,6 +2,7 @@ import {
   Directive,
   EventEmitter,
   Input,
+  NgZone,
   OnChanges,
   OnDestroy,
   OnInit,
@@ -62,7 +63,10 @@ export class YMapOpenMapsButtonDirective implements OnInit, OnChanges, OnDestroy
     YReadyEvent<YMapOpenMapsButton>
   >();
 
-  constructor(private readonly yMapControlsDirective: YMapControlsDirective) {}
+  constructor(
+    private readonly ngZone: NgZone,
+    private readonly yMapControlsDirective: YMapControlsDirective,
+  ) {}
 
   ngOnInit() {
     this.yMapControlsDirective.controls$
@@ -84,9 +88,12 @@ export class YMapOpenMapsButtonDirective implements OnInit, OnChanges, OnDestroy
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    if (this.control) {
-      this.control.update(changes['props'].currentValue);
-    }
+    // It must be run outside a zone; otherwise, all async events within this call will cause ticks.
+    this.ngZone.runOutsideAngular(() => {
+      if (this.control) {
+        this.control.update(changes['props'].currentValue);
+      }
+    });
   }
 
   ngOnDestroy() {

--- a/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-scale-control/y-map-scale-control.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-scale-control/y-map-scale-control.directive.ts
@@ -2,6 +2,7 @@ import {
   Directive,
   EventEmitter,
   Input,
+  NgZone,
   OnChanges,
   OnDestroy,
   OnInit,
@@ -58,7 +59,10 @@ export class YMapScaleControlDirective implements OnInit, OnChanges, OnDestroy {
     YReadyEvent<YMapScaleControl>
   >();
 
-  constructor(private readonly yMapControlsDirective: YMapControlsDirective) {}
+  constructor(
+    private readonly ngZone: NgZone,
+    private readonly yMapControlsDirective: YMapControlsDirective,
+  ) {}
 
   ngOnInit() {
     this.yMapControlsDirective.controls$
@@ -71,9 +75,12 @@ export class YMapScaleControlDirective implements OnInit, OnChanges, OnDestroy {
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    if (this.control) {
-      this.control.update(changes['props'].currentValue);
-    }
+    // It must be run outside a zone; otherwise, all async events within this call will cause ticks.
+    this.ngZone.runOutsideAngular(() => {
+      if (this.control) {
+        this.control.update(changes['props'].currentValue);
+      }
+    });
   }
 
   ngOnDestroy() {

--- a/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-zoom-control/y-map-zoom-control.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-zoom-control/y-map-zoom-control.directive.ts
@@ -2,6 +2,7 @@ import {
   Directive,
   EventEmitter,
   Input,
+  NgZone,
   OnChanges,
   OnDestroy,
   OnInit,
@@ -66,7 +67,10 @@ export class YMapZoomControlDirective implements OnInit, OnChanges, OnDestroy {
     YReadyEvent<YMapZoomControl>
   >();
 
-  constructor(private readonly yMapControlsDirective: YMapControlsDirective) {}
+  constructor(
+    private readonly ngZone: NgZone,
+    private readonly yMapControlsDirective: YMapControlsDirective,
+  ) {}
 
   ngOnInit() {
     this.yMapControlsDirective.controls$
@@ -88,9 +92,12 @@ export class YMapZoomControlDirective implements OnInit, OnChanges, OnDestroy {
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    if (this.control) {
-      this.control.update(changes['props'].currentValue);
-    }
+    // It must be run outside a zone; otherwise, all async events within this call will cause ticks.
+    this.ngZone.runOutsideAngular(() => {
+      if (this.control) {
+        this.control.update(changes['props'].currentValue);
+      }
+    });
   }
 
   ngOnDestroy() {

--- a/libs/angular-yandex-maps-v3/src/lib/services/y-api-loader/y-api-loader.service.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/services/y-api-loader/y-api-loader.service.ts
@@ -118,6 +118,9 @@ export class YApiLoaderService {
           // ready confirms that the API and DOM are ready for use,
           // we can return of(window.ymaps3), but calling ready is safer, I believe.
           return from(apiObject.ready).pipe(
+            // Each nested operator should run outside the zone.
+            // Refer to the comment above for the reason why we need to exit the zone.
+            exitZone(this.ngZone),
             // Actually, we need to update it only if they are not equal,
             // it happens if we change the configuration which required new window.ymaps3.
             tap(() => ((window as any).ymaps3 = apiObject)),
@@ -159,7 +162,12 @@ export class YApiLoaderService {
 
         const error = fromEvent(script, 'error').pipe(switchMap(throwError));
 
-        return merge(load, error).pipe(take(1));
+        return merge(load, error).pipe(
+          // Each nested operator should run outside the zone.
+          // Refer to the comment above for the reason why we need to exit the zone.
+          exitZone(this.ngZone),
+          take(1),
+        );
       }),
     );
   }


### PR DESCRIPTION
## What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Documentation content changes

## Which library does this PR affect?

- [x] angular-yandex-maps-v2
- [x] angular-yandex-maps-v3

## What is the current behavior?

Closes #251

## What is the new behavior?

Updating a configuration doesn't cause ticks.
NgOnChanges is outside the zone.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
