### PR TITLE
feat: support removeChild from parent on destroy

### DIFF
--- a/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-clusterer/y-map-clusterer.directive.spec.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-clusterer/y-map-clusterer.directive.spec.ts
@@ -156,4 +156,15 @@ describe('YMapClustererDirective', () => {
 
     expect(clustererInstance.update).toHaveBeenCalledWith(expect.objectContaining(props));
   });
+
+  it('should remove entity on destroy', async () => {
+    fixture.detectChanges();
+
+    // ymaps3.import is async, wait for it
+    await new Promise(process.nextTick);
+
+    fixture.destroy();
+
+    expect(mapInstance.removeChild).toHaveBeenCalledWith(clustererInstance);
+  });
 });

--- a/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-clusterer/y-map-clusterer.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-clusterer/y-map-clusterer.directive.ts
@@ -183,6 +183,10 @@ export class YMapClustererDirective implements AfterContentInit, OnDestroy, OnCh
   }
 
   ngOnDestroy() {
+    if (this.clusterer) {
+      this.yMapComponent.map$.value?.removeChild(this.clusterer);
+    }
+
     this.destroy$.next();
     this.destroy$.complete();
   }

--- a/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-default-marker/y-map-default-marker.directive.spec.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-default-marker/y-map-default-marker.directive.spec.ts
@@ -125,4 +125,15 @@ describe('YMapDefaultMarkerDirective', () => {
 
     expect(markerInstance.update).toHaveBeenCalledWith(props);
   });
+
+  it('should remove entity on destroy', async () => {
+    fixture.detectChanges();
+
+    // ymaps3.import is async, wait for it
+    await new Promise(process.nextTick);
+
+    fixture.destroy();
+
+    expect(mapInstance.removeChild).toHaveBeenCalledWith(markerInstance);
+  });
 });

--- a/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-default-marker/y-map-default-marker.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-default-marker/y-map-default-marker.directive.ts
@@ -99,6 +99,10 @@ export class YMapDefaultMarkerDirective implements OnInit, OnDestroy, OnChanges 
   }
 
   ngOnDestroy() {
+    if (this.marker) {
+      this.yMapComponent.map$.value?.removeChild(this.marker);
+    }
+
     this.destroy$.next();
     this.destroy$.complete();
   }

--- a/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-feature-data-source/y-map-feature-data-source.directive.spec.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-feature-data-source/y-map-feature-data-source.directive.spec.ts
@@ -106,4 +106,11 @@ describe('YMapFeatureDataSourceDirective', () => {
 
     expect(sourceInstance.update).toHaveBeenCalledWith(props);
   });
+
+  it('should remove entity on destroy', async () => {
+    fixture.detectChanges();
+    fixture.destroy();
+
+    expect(mapInstance.removeChild).toHaveBeenCalledWith(sourceInstance);
+  });
 });

--- a/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-feature-data-source/y-map-feature-data-source.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-feature-data-source/y-map-feature-data-source.directive.ts
@@ -77,6 +77,10 @@ export class YMapFeatureDataSourceDirective implements OnInit, OnDestroy, OnChan
   }
 
   ngOnDestroy() {
+    if (this.source) {
+      this.yMapComponent.map$.value?.removeChild(this.source);
+    }
+
     this.destroy$.next();
     this.destroy$.complete();
   }

--- a/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-feature/y-map-feature.directive.spec.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-feature/y-map-feature.directive.spec.ts
@@ -118,4 +118,11 @@ describe('YMapFeatureDirective', () => {
 
     expect(featureInstance.update).toHaveBeenCalledWith(props);
   });
+
+  it('should remove entity on destroy', async () => {
+    fixture.detectChanges();
+    fixture.destroy();
+
+    expect(mapInstance.removeChild).toHaveBeenCalledWith(featureInstance);
+  });
 });

--- a/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-feature/y-map-feature.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-feature/y-map-feature.directive.ts
@@ -98,6 +98,10 @@ export class YMapFeatureDirective implements OnInit, OnDestroy, OnChanges {
   }
 
   ngOnDestroy() {
+    if (this.feature) {
+      this.yMapComponent.map$.value?.removeChild(this.feature);
+    }
+
     this.destroy$.next();
     this.destroy$.complete();
   }

--- a/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-hint/y-map-hint.directive.spec.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-hint/y-map-hint.directive.spec.ts
@@ -134,4 +134,15 @@ describe('YMapHintDirective', () => {
 
     expect(hintInstance.update).toHaveBeenCalledWith(props);
   });
+
+  it('should remove entity on destroy', async () => {
+    fixture.detectChanges();
+
+    // ymaps3.import is async, wait for it
+    await new Promise(process.nextTick);
+
+    fixture.destroy();
+
+    expect(mapInstance.removeChild).toHaveBeenCalledWith(hintInstance);
+  });
 });

--- a/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-hint/y-map-hint.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-hint/y-map-hint.directive.ts
@@ -137,6 +137,10 @@ export class YMapHintDirective implements AfterContentInit, OnChanges, OnDestroy
   }
 
   ngOnDestroy() {
+    if (this.hint) {
+      this.yMapComponent.map$.value?.removeChild(this.hint);
+    }
+
     this.destroy$.next();
     this.destroy$.complete();
   }

--- a/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-listener/y-map-listener.directive.spec.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-listener/y-map-listener.directive.spec.ts
@@ -107,4 +107,11 @@ describe('YMapListenerDirective', () => {
 
     expect(listenerInstance.update).toHaveBeenCalledWith(props);
   });
+
+  it('should remove entity on destroy', async () => {
+    fixture.detectChanges();
+    fixture.destroy();
+
+    expect(mapInstance.removeChild).toHaveBeenCalledWith(listenerInstance);
+  });
 });

--- a/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-listener/y-map-listener.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-listener/y-map-listener.directive.ts
@@ -83,6 +83,10 @@ export class YMapListenerDirective implements OnInit, OnChanges, OnDestroy {
   }
 
   ngOnDestroy() {
+    if (this.listener) {
+      this.yMapComponent.map$.value?.removeChild(this.listener);
+    }
+
     this.destroy$.next();
     this.destroy$.complete();
   }

--- a/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-marker/y-map-marker.directive.spec.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-marker/y-map-marker.directive.spec.ts
@@ -115,4 +115,11 @@ describe('YMapMarkerDirective', () => {
 
     expect(markerInstance.update).toHaveBeenCalledWith(props);
   });
+
+  it('should remove entity on destroy', async () => {
+    fixture.detectChanges();
+    fixture.destroy();
+
+    expect(mapInstance.removeChild).toHaveBeenCalledWith(markerInstance);
+  });
 });

--- a/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-marker/y-map-marker.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-marker/y-map-marker.directive.ts
@@ -107,6 +107,10 @@ export class YMapMarkerDirective implements AfterViewInit, OnDestroy, OnChanges 
   }
 
   ngOnDestroy() {
+    if (this.marker) {
+      this.yMapComponent.map$.value?.removeChild(this.marker);
+    }
+
     this.destroy$.next();
     this.destroy$.complete();
   }

--- a/libs/angular-yandex-maps-v3/src/lib/components/common/y-map/y-map.component.spec.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/common/y-map/y-map.component.spec.ts
@@ -145,4 +145,11 @@ describe('YMapComponent', () => {
 
     expect(mapInstance.update).toHaveBeenCalledWith(props);
   });
+
+  it('should destroy entity on destroy', async () => {
+    fixture.detectChanges();
+    fixture.destroy();
+
+    expect(mapInstance.destroy).toHaveBeenCalled();
+  });
 });

--- a/libs/angular-yandex-maps-v3/src/lib/components/common/y-map/y-map.component.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/common/y-map/y-map.component.ts
@@ -101,6 +101,7 @@ export class YMapComponent implements AfterViewInit, OnChanges, OnDestroy {
   }
 
   ngOnDestroy() {
+    this.map$.value?.destroy();
     this.destroy$.next();
     this.destroy$.complete();
   }

--- a/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-control-button/y-map-control-button.directive.spec.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-control-button/y-map-control-button.directive.spec.ts
@@ -113,4 +113,11 @@ describe('YMapControlButtonDirective', () => {
 
     expect(controlInstance.update).toHaveBeenCalledWith(props);
   });
+
+  it('should remove entity on destroy', async () => {
+    fixture.detectChanges();
+    fixture.destroy();
+
+    expect(controlsInstance.removeChild).toHaveBeenCalledWith(controlInstance);
+  });
 });

--- a/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-control-button/y-map-control-button.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-control-button/y-map-control-button.directive.ts
@@ -90,6 +90,10 @@ export class YMapControlButtonDirective implements OnInit, OnChanges, OnDestroy 
   }
 
   ngOnDestroy() {
+    if (this.control) {
+      this.yMapControlsDirective.controls$.value?.removeChild(this.control);
+    }
+
     this.destroy$.next();
     this.destroy$.complete();
   }

--- a/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-control-common-button/y-map-control-common-button.directive.spec.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-control-common-button/y-map-control-common-button.directive.spec.ts
@@ -113,4 +113,11 @@ describe('YMapControlCommonButtonDirective', () => {
 
     expect(controlInstance.update).toHaveBeenCalledWith(props);
   });
+
+  it('should remove entity on destroy', async () => {
+    fixture.detectChanges();
+    fixture.destroy();
+
+    expect(controlsInstance.removeChild).toHaveBeenCalledWith(controlInstance);
+  });
 });

--- a/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-control-common-button/y-map-control-common-button.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-control-common-button/y-map-control-common-button.directive.ts
@@ -93,6 +93,10 @@ export class YMapControlCommonButtonDirective implements OnInit, OnChanges, OnDe
   }
 
   ngOnDestroy() {
+    if (this.control) {
+      this.yMapControlsDirective.controls$.value?.removeChild(this.control);
+    }
+
     this.destroy$.next();
     this.destroy$.complete();
   }

--- a/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-control/y-map-control.directive.spec.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-control/y-map-control.directive.spec.ts
@@ -113,4 +113,11 @@ describe('YMapControlDirective', () => {
 
     expect(controlInstance.update).toHaveBeenCalledWith(props);
   });
+
+  it('should remove entity on destroy', async () => {
+    fixture.detectChanges();
+    fixture.destroy();
+
+    expect(controlsInstance.removeChild).toHaveBeenCalledWith(controlInstance);
+  });
 });

--- a/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-control/y-map-control.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-control/y-map-control.directive.ts
@@ -102,6 +102,10 @@ export class YMapControlDirective implements AfterViewInit, OnChanges, OnDestroy
   }
 
   ngOnDestroy() {
+    if (this.control) {
+      this.yMapControlsDirective.controls$.value?.removeChild(this.control);
+    }
+
     this.destroy$.next();
     this.destroy$.complete();
   }

--- a/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-controls/y-map-controls.directive.spec.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-controls/y-map-controls.directive.spec.ts
@@ -121,4 +121,11 @@ describe('YMapControlsDirective', () => {
 
     expect(controlsInstance.update).toHaveBeenCalledWith(props);
   });
+
+  it('should remove entity on destroy', async () => {
+    fixture.detectChanges();
+    fixture.destroy();
+
+    expect(mapInstance.removeChild).toHaveBeenCalledWith(controlsInstance);
+  });
 });

--- a/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-controls/y-map-controls.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-controls/y-map-controls.directive.ts
@@ -88,6 +88,10 @@ export class YMapControlsDirective implements OnInit, OnChanges, OnDestroy {
   }
 
   ngOnDestroy() {
+    if (this.controls$.value) {
+      this.yMapComponent.map$.value?.removeChild(this.controls$.value);
+    }
+
     this.destroy$.next();
     this.destroy$.complete();
   }

--- a/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-geolocation-control/y-map-geolocation-control.directive.spec.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-geolocation-control/y-map-geolocation-control.directive.spec.ts
@@ -120,4 +120,15 @@ describe('YMapGeolocationControlDirective', () => {
 
     expect(controlInstance.update).toHaveBeenCalledWith(props);
   });
+
+  it('should remove entity on destroy', async () => {
+    fixture.detectChanges();
+
+    // ymaps3.import is async, wait for it
+    await new Promise(process.nextTick);
+
+    fixture.destroy();
+
+    expect(controlsInstance.removeChild).toHaveBeenCalledWith(controlInstance);
+  });
 });

--- a/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-geolocation-control/y-map-geolocation-control.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-geolocation-control/y-map-geolocation-control.directive.ts
@@ -96,6 +96,10 @@ export class YMapGeolocationControlDirective implements OnInit, OnChanges, OnDes
   }
 
   ngOnDestroy() {
+    if (this.control) {
+      this.yMapControlsDirective.controls$.value?.removeChild(this.control);
+    }
+
     this.destroy$.next();
     this.destroy$.complete();
   }

--- a/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-open-maps-button/y-map-open-maps-button.directive.spec.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-open-maps-button/y-map-open-maps-button.directive.spec.ts
@@ -118,4 +118,15 @@ describe('YMapOpenMapsButtonDirective', () => {
 
     expect(controlInstance.update).toHaveBeenCalledWith(props);
   });
+
+  it('should remove entity on destroy', async () => {
+    fixture.detectChanges();
+
+    // ymaps3.import is async, wait for it
+    await new Promise(process.nextTick);
+
+    fixture.destroy();
+
+    expect(controlsInstance.removeChild).toHaveBeenCalledWith(controlInstance);
+  });
 });

--- a/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-open-maps-button/y-map-open-maps-button.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-open-maps-button/y-map-open-maps-button.directive.ts
@@ -96,6 +96,10 @@ export class YMapOpenMapsButtonDirective implements OnInit, OnChanges, OnDestroy
   }
 
   ngOnDestroy() {
+    if (this.control) {
+      this.yMapControlsDirective.controls$.value?.removeChild(this.control);
+    }
+
     this.destroy$.next();
     this.destroy$.complete();
   }

--- a/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-scale-control/y-map-scale-control.directive.spec.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-scale-control/y-map-scale-control.directive.spec.ts
@@ -105,4 +105,11 @@ describe('YMapScaleControlDirective', () => {
 
     expect(controlInstance.update).toHaveBeenCalledWith(props);
   });
+
+  it('should remove entity on destroy', async () => {
+    fixture.detectChanges();
+    fixture.destroy();
+
+    expect(controlsInstance.removeChild).toHaveBeenCalledWith(controlInstance);
+  });
 });

--- a/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-scale-control/y-map-scale-control.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-scale-control/y-map-scale-control.directive.ts
@@ -83,6 +83,10 @@ export class YMapScaleControlDirective implements OnInit, OnChanges, OnDestroy {
   }
 
   ngOnDestroy() {
+    if (this.control) {
+      this.yMapControlsDirective.controls$.value?.removeChild(this.control);
+    }
+
     this.destroy$.next();
     this.destroy$.complete();
   }

--- a/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-zoom-control/y-map-zoom-control.directive.spec.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-zoom-control/y-map-zoom-control.directive.spec.ts
@@ -128,4 +128,15 @@ describe('YMapZoomControlDirective', () => {
 
     expect(controlInstance.update).toHaveBeenCalledWith(props);
   });
+
+  it('should remove entity on destroy', async () => {
+    fixture.detectChanges();
+
+    // ymaps3.import is async, wait for it
+    await new Promise(process.nextTick);
+
+    fixture.destroy();
+
+    expect(controlsInstance.removeChild).toHaveBeenCalledWith(controlInstance);
+  });
 });

--- a/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-zoom-control/y-map-zoom-control.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-zoom-control/y-map-zoom-control.directive.ts
@@ -100,6 +100,10 @@ export class YMapZoomControlDirective implements OnInit, OnChanges, OnDestroy {
   }
 
   ngOnDestroy() {
+    if (this.control) {
+      this.yMapControlsDirective.controls$.value?.removeChild(this.control);
+    }
+
     this.destroy$.next();
     this.destroy$.complete();
   }

--- a/libs/angular-yandex-maps-v3/src/lib/components/layers/y-map-default-features-layer/y-map-default-features-layer.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/layers/y-map-default-features-layer/y-map-default-features-layer.directive.ts
@@ -87,6 +87,10 @@ export class YMapDefaultFeaturesLayerDirective implements OnInit, OnDestroy, OnC
   }
 
   ngOnDestroy() {
+    if (this.layer) {
+      this.yMapComponent.map$.value?.removeChild(this.layer);
+    }
+
     this.destroy$.next();
     this.destroy$.complete();
   }

--- a/libs/angular-yandex-maps-v3/src/lib/components/layers/y-map-default-scheme-layer/y-map-default-scheme-layer.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/layers/y-map-default-scheme-layer/y-map-default-scheme-layer.directive.ts
@@ -83,6 +83,10 @@ export class YMapDefaultSchemeLayerDirective implements OnInit, OnDestroy, OnCha
   }
 
   ngOnDestroy() {
+    if (this.layer) {
+      this.yMapComponent.map$.value?.removeChild(this.layer);
+    }
+
     this.destroy$.next();
     this.destroy$.complete();
   }

--- a/libs/angular-yandex-maps-v3/src/lib/components/layers/y-map-layer/y-map-layer.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/layers/y-map-layer/y-map-layer.directive.ts
@@ -84,6 +84,10 @@ export class YMapLayerDirective implements OnInit, OnDestroy, OnChanges {
   }
 
   ngOnDestroy() {
+    if (this.layer) {
+      this.yMapComponent.map$.value?.removeChild(this.layer);
+    }
+
     this.destroy$.next();
     this.destroy$.complete();
   }

--- a/libs/angular-yandex-maps-v3/src/test-utils.ts
+++ b/libs/angular-yandex-maps-v3/src/test-utils.ts
@@ -81,6 +81,7 @@ export const mockImport = (constructorName: string, constructor: unknown): jest.
  */
 export const mockYMapInstance = () => ({
   addChild: jest.fn(),
+  removeChild: jest.fn(),
   update: jest.fn(),
   destroy: jest.fn(),
 });
@@ -394,6 +395,7 @@ export const mockYMapControlCommonButtonConstructor = (
 export const mockYMapControlsInstance = () => ({
   update: jest.fn(),
   addChild: jest.fn(),
+  removeChild: jest.fn(),
 });
 
 /**


### PR DESCRIPTION
## What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Documentation content changes

## Which library does this PR affect?

- [ ] angular-yandex-maps-v2
- [x] angular-yandex-maps-v3

## What is the current behavior?

Closes #274

## What is the new behavior?

When a component is destroyed (ngOnDestroy), it's removed from a parent by calling `parent.removeChild`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
