### PR TITLE
chore: add consistent-type-imports ESLint rule

### DIFF
--- a/apps/angular-yandex-maps-v2-demo/src/app/app.component.ts
+++ b/apps/angular-yandex-maps-v2-demo/src/app/app.component.ts
@@ -1,7 +1,8 @@
-import { ChangeDetectionStrategy, Component, DoCheck } from '@angular/core';
+import type { DoCheck } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import type { YaConfig, YaReadyEvent } from 'angular8-yandex-maps';
 import {
   YaClustererComponent,
-  YaConfig,
   YaControlDirective,
   YaGeoObjectDirective,
   YaMapComponent,
@@ -9,7 +10,6 @@ import {
   YaObjectManagerDirective,
   YaPanoramaDirective,
   YaPlacemarkDirective,
-  YaReadyEvent,
 } from 'angular8-yandex-maps';
 
 import { environment } from '../environments/environment';

--- a/apps/angular-yandex-maps-v2-demo/src/app/app.config.ts
+++ b/apps/angular-yandex-maps-v2-demo/src/app/app.config.ts
@@ -1,5 +1,7 @@
-import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
-import { provideYaConfig, YaConfig } from 'angular8-yandex-maps';
+import type { ApplicationConfig } from '@angular/core';
+import { provideZoneChangeDetection } from '@angular/core';
+import type { YaConfig } from 'angular8-yandex-maps';
+import { provideYaConfig } from 'angular8-yandex-maps';
 import { BehaviorSubject } from 'rxjs';
 
 import { environment } from '../environments/environment';

--- a/apps/angular-yandex-maps-v3-demo/src/app/app.component.ts
+++ b/apps/angular-yandex-maps-v3-demo/src/app/app.component.ts
@@ -1,8 +1,9 @@
-import { ChangeDetectionStrategy, Component, DoCheck } from '@angular/core';
+import type { DoCheck } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import type { YMapFeature, YMapHotspot, YMapMarker } from '@yandex/ymaps3-types/imperative';
-import { Feature } from '@yandex/ymaps3-types/packages/clusterer';
+import type { Feature } from '@yandex/ymaps3-types/packages/clusterer';
+import type { YConfig } from 'angular-yandex-maps-v3';
 import {
-  YConfig,
   YMapClustererDirective,
   YMapComponent,
   YMapControlButtonDirective,

--- a/apps/angular-yandex-maps-v3-demo/src/app/app.config.ts
+++ b/apps/angular-yandex-maps-v3-demo/src/app/app.config.ts
@@ -1,5 +1,7 @@
-import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
-import { provideYConfig, YConfig } from 'angular-yandex-maps-v3';
+import type { ApplicationConfig } from '@angular/core';
+import { provideZoneChangeDetection } from '@angular/core';
+import type { YConfig } from 'angular-yandex-maps-v3';
+import { provideYConfig } from 'angular-yandex-maps-v3';
 import { BehaviorSubject } from 'rxjs';
 
 import { environment } from '../environments/environment';

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -51,6 +51,7 @@ export default [
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-non-null-assertion': 'off',
       '@typescript-eslint/no-empty-function': 'off',
+      '@typescript-eslint/consistent-type-imports': 'error',
     },
   },
 ];

--- a/libs/angular-yandex-maps-v2/src/lib/components/ya-clusterer/ya-clusterer.component.spec.ts
+++ b/libs/angular-yandex-maps-v2/src/lib/components/ya-clusterer/ya-clusterer.component.spec.ts
@@ -1,5 +1,6 @@
 import { Component, ViewChild } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { BehaviorSubject } from 'rxjs';
 
 import {
@@ -11,7 +12,7 @@ import {
   mockPlacemarkConstructor,
   mockPlacemarkInstance,
 } from '../../../test-utils';
-import { YaReadyEvent } from '../../types/ya-ready-event';
+import type { YaReadyEvent } from '../../types/ya-ready-event';
 import { YaGeoObjectDirective } from '../ya-geoobject/ya-geoobject.directive';
 import { YaMapComponent } from '../ya-map/ya-map.component';
 import { YaPlacemarkDirective } from '../ya-placemark/ya-placemark.directive';

--- a/libs/angular-yandex-maps-v2/src/lib/components/ya-clusterer/ya-clusterer.component.ts
+++ b/libs/angular-yandex-maps-v2/src/lib/components/ya-clusterer/ya-clusterer.component.ts
@@ -1,5 +1,5 @@
+import type { AfterContentInit, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
 import {
-  AfterContentInit,
   ChangeDetectionStrategy,
   Component,
   ContentChildren,
@@ -7,17 +7,15 @@ import {
   inject,
   Input,
   NgZone,
-  OnChanges,
-  OnDestroy,
   Output,
   QueryList,
-  SimpleChanges,
 } from '@angular/core';
-import { Observable, Subject, takeUntil } from 'rxjs';
+import type { Observable } from 'rxjs';
+import { Subject, takeUntil } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
-import { YaEvent } from '../../types/ya-event';
-import { YaReadyEvent } from '../../types/ya-ready-event';
+import type { YaEvent } from '../../types/ya-event';
+import type { YaReadyEvent } from '../../types/ya-ready-event';
 import { EventManager } from '../../utils/event-manager/event-manager';
 import { YaGeoObjectDirective } from '../ya-geoobject/ya-geoobject.directive';
 import { YaMapComponent } from '../ya-map/ya-map.component';

--- a/libs/angular-yandex-maps-v2/src/lib/components/ya-control/ya-control.directive.spec.ts
+++ b/libs/angular-yandex-maps-v2/src/lib/components/ya-control/ya-control.directive.spec.ts
@@ -1,11 +1,13 @@
 import { Component, ViewChild } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { BehaviorSubject } from 'rxjs';
 
 import { mockMapInstance, mockRoutePanel, mockRoutePanelConstructor } from '../../../test-utils';
-import { YaReadyEvent } from '../../types/ya-ready-event';
+import type { YaReadyEvent } from '../../types/ya-ready-event';
 import { YaMapComponent } from '../ya-map/ya-map.component';
-import { YaControlDirective, YaControlType } from './ya-control.directive';
+import type { YaControlType } from './ya-control.directive';
+import { YaControlDirective } from './ya-control.directive';
 
 @Component({
   imports: [YaControlDirective],

--- a/libs/angular-yandex-maps-v2/src/lib/components/ya-control/ya-control.directive.ts
+++ b/libs/angular-yandex-maps-v2/src/lib/components/ya-control/ya-control.directive.ts
@@ -1,17 +1,9 @@
-import {
-  Directive,
-  EventEmitter,
-  inject,
-  Input,
-  OnChanges,
-  OnDestroy,
-  OnInit,
-  Output,
-} from '@angular/core';
+import type { OnChanges, OnDestroy, OnInit } from '@angular/core';
+import { Directive, EventEmitter, inject, Input, Output } from '@angular/core';
 import { Subject, takeUntil } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
-import { YaReadyEvent } from '../../types/ya-ready-event';
+import type { YaReadyEvent } from '../../types/ya-ready-event';
 import { YaMapComponent } from '../ya-map/ya-map.component';
 
 /**

--- a/libs/angular-yandex-maps-v2/src/lib/components/ya-geoobject/ya-geoobject.directive.spec.ts
+++ b/libs/angular-yandex-maps-v2/src/lib/components/ya-geoobject/ya-geoobject.directive.spec.ts
@@ -1,5 +1,6 @@
 import { Component, ViewChild } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { BehaviorSubject } from 'rxjs';
 
 import {
@@ -7,7 +8,7 @@ import {
   mockGeoObjectInstance,
   mockMapInstance,
 } from '../../../test-utils';
-import { YaReadyEvent } from '../../types/ya-ready-event';
+import type { YaReadyEvent } from '../../types/ya-ready-event';
 import { YaMapComponent } from '../ya-map/ya-map.component';
 import { YaGeoObjectDirective } from './ya-geoobject.directive';
 

--- a/libs/angular-yandex-maps-v2/src/lib/components/ya-geoobject/ya-geoobject.directive.ts
+++ b/libs/angular-yandex-maps-v2/src/lib/components/ya-geoobject/ya-geoobject.directive.ts
@@ -1,20 +1,11 @@
-import {
-  Directive,
-  EventEmitter,
-  inject,
-  Input,
-  NgZone,
-  OnChanges,
-  OnDestroy,
-  OnInit,
-  Output,
-  SimpleChanges,
-} from '@angular/core';
-import { Observable, Subject, takeUntil } from 'rxjs';
+import type { OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
+import { Directive, EventEmitter, inject, Input, NgZone, Output } from '@angular/core';
+import type { Observable } from 'rxjs';
+import { Subject, takeUntil } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
-import { YaEvent } from '../../types/ya-event';
-import { YaReadyEvent } from '../../types/ya-ready-event';
+import type { YaEvent } from '../../types/ya-event';
+import type { YaReadyEvent } from '../../types/ya-ready-event';
 import { EventManager } from '../../utils/event-manager/event-manager';
 import { YaMapComponent } from '../ya-map/ya-map.component';
 

--- a/libs/angular-yandex-maps-v2/src/lib/components/ya-map/ya-map.component.spec.ts
+++ b/libs/angular-yandex-maps-v2/src/lib/components/ya-map/ya-map.component.spec.ts
@@ -1,11 +1,13 @@
 import { Component, ViewChild } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { BehaviorSubject, Subject } from 'rxjs';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
+import type { Subject } from 'rxjs';
+import { BehaviorSubject } from 'rxjs';
 
 import { mockMapConstructor, mockMapInstance } from '../../../test-utils';
 import { YaApiLoaderService } from '../../services/ya-api-loader/ya-api-loader.service';
-import { YaConfig } from '../../types/ya-config';
-import { YaReadyEvent } from '../../types/ya-ready-event';
+import type { YaConfig } from '../../types/ya-config';
+import type { YaReadyEvent } from '../../types/ya-ready-event';
 import * as GenerateRandomIdModule from '../../utils/generate-random-id/generate-random-id';
 import { YaMapComponent } from './ya-map.component';
 

--- a/libs/angular-yandex-maps-v2/src/lib/components/ya-map/ya-map.component.ts
+++ b/libs/angular-yandex-maps-v2/src/lib/components/ya-map/ya-map.component.ts
@@ -1,23 +1,20 @@
+import type { AfterViewInit, ElementRef, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
 import {
-  AfterViewInit,
   ChangeDetectionStrategy,
   Component,
-  ElementRef,
   EventEmitter,
   inject,
   Input,
   NgZone,
-  OnChanges,
-  OnDestroy,
   Output,
-  SimpleChanges,
   ViewChild,
 } from '@angular/core';
-import { BehaviorSubject, Observable, Subject, takeUntil } from 'rxjs';
+import type { Observable } from 'rxjs';
+import { BehaviorSubject, Subject, takeUntil } from 'rxjs';
 
 import { YaApiLoaderService } from '../../services/ya-api-loader/ya-api-loader.service';
-import { YaEvent } from '../../types/ya-event';
-import { YaReadyEvent } from '../../types/ya-ready-event';
+import type { YaEvent } from '../../types/ya-event';
+import type { YaReadyEvent } from '../../types/ya-ready-event';
 import { EventManager } from '../../utils/event-manager/event-manager';
 import { generateRandomId } from '../../utils/generate-random-id/generate-random-id';
 

--- a/libs/angular-yandex-maps-v2/src/lib/components/ya-multiroute/ya-multiroute.directive.spec.ts
+++ b/libs/angular-yandex-maps-v2/src/lib/components/ya-multiroute/ya-multiroute.directive.spec.ts
@@ -1,9 +1,10 @@
 import { Component, ViewChild } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { BehaviorSubject } from 'rxjs';
 
 import { mockMapInstance, mockMultiroute, mockMultirouteConstructor } from '../../../test-utils';
-import { YaReadyEvent } from '../../types/ya-ready-event';
+import type { YaReadyEvent } from '../../types/ya-ready-event';
 import { YaMapComponent } from '../ya-map/ya-map.component';
 import { YaMultirouteDirective } from './ya-multiroute.directive';
 

--- a/libs/angular-yandex-maps-v2/src/lib/components/ya-multiroute/ya-multiroute.directive.ts
+++ b/libs/angular-yandex-maps-v2/src/lib/components/ya-multiroute/ya-multiroute.directive.ts
@@ -1,20 +1,11 @@
-import {
-  Directive,
-  EventEmitter,
-  inject,
-  Input,
-  NgZone,
-  OnChanges,
-  OnDestroy,
-  OnInit,
-  Output,
-  SimpleChanges,
-} from '@angular/core';
-import { Observable, Subject, takeUntil } from 'rxjs';
+import type { OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
+import { Directive, EventEmitter, inject, Input, NgZone, Output } from '@angular/core';
+import type { Observable } from 'rxjs';
+import { Subject, takeUntil } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
-import { YaEvent } from '../../types/ya-event';
-import { YaReadyEvent } from '../../types/ya-ready-event';
+import type { YaEvent } from '../../types/ya-event';
+import type { YaReadyEvent } from '../../types/ya-ready-event';
 import { EventManager } from '../../utils/event-manager/event-manager';
 import { YaMapComponent } from '../ya-map/ya-map.component';
 

--- a/libs/angular-yandex-maps-v2/src/lib/components/ya-object-manager/ya-object-manager.directive.spec.ts
+++ b/libs/angular-yandex-maps-v2/src/lib/components/ya-object-manager/ya-object-manager.directive.spec.ts
@@ -1,9 +1,10 @@
 import { Component, ViewChild } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { BehaviorSubject } from 'rxjs';
 
 import { mockManagerConstructor, mockMapInstance, mockObjectManager } from '../../../test-utils';
-import { YaReadyEvent } from '../../types/ya-ready-event';
+import type { YaReadyEvent } from '../../types/ya-ready-event';
 import { YaMapComponent } from '../ya-map/ya-map.component';
 import { YaObjectManagerDirective } from './ya-object-manager.directive';
 

--- a/libs/angular-yandex-maps-v2/src/lib/components/ya-object-manager/ya-object-manager.directive.ts
+++ b/libs/angular-yandex-maps-v2/src/lib/components/ya-object-manager/ya-object-manager.directive.ts
@@ -1,20 +1,11 @@
-import {
-  Directive,
-  EventEmitter,
-  inject,
-  Input,
-  NgZone,
-  OnChanges,
-  OnDestroy,
-  OnInit,
-  Output,
-  SimpleChanges,
-} from '@angular/core';
-import { Observable, Subject, takeUntil } from 'rxjs';
+import type { OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
+import { Directive, EventEmitter, inject, Input, NgZone, Output } from '@angular/core';
+import type { Observable } from 'rxjs';
+import { Subject, takeUntil } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
-import { YaEvent } from '../../types/ya-event';
-import { YaReadyEvent } from '../../types/ya-ready-event';
+import type { YaEvent } from '../../types/ya-event';
+import type { YaReadyEvent } from '../../types/ya-ready-event';
 import { EventManager } from '../../utils/event-manager/event-manager';
 import { YaMapComponent } from '../ya-map/ya-map.component';
 

--- a/libs/angular-yandex-maps-v2/src/lib/components/ya-panorama/ya-panorama.directive.spec.ts
+++ b/libs/angular-yandex-maps-v2/src/lib/components/ya-panorama/ya-panorama.directive.spec.ts
@@ -1,5 +1,6 @@
 import { Component, ViewChild } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { BehaviorSubject } from 'rxjs';
 
 import {
@@ -8,7 +9,7 @@ import {
   mockPlayer,
   mockPlayerConstructor,
 } from '../../../test-utils';
-import { YaReadyEvent } from '../../types/ya-ready-event';
+import type { YaReadyEvent } from '../../types/ya-ready-event';
 import { YaMapComponent } from '../ya-map/ya-map.component';
 import { YaPanoramaDirective } from './ya-panorama.directive';
 

--- a/libs/angular-yandex-maps-v2/src/lib/components/ya-panorama/ya-panorama.directive.ts
+++ b/libs/angular-yandex-maps-v2/src/lib/components/ya-panorama/ya-panorama.directive.ts
@@ -1,20 +1,11 @@
-import {
-  Directive,
-  EventEmitter,
-  inject,
-  Input,
-  NgZone,
-  OnChanges,
-  OnDestroy,
-  OnInit,
-  Output,
-  SimpleChanges,
-} from '@angular/core';
-import { from, Observable, Subject, takeUntil } from 'rxjs';
+import type { OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
+import { Directive, EventEmitter, inject, Input, NgZone, Output } from '@angular/core';
+import type { Observable } from 'rxjs';
+import { from, Subject, takeUntil } from 'rxjs';
 import { filter, map, switchMap } from 'rxjs/operators';
 
-import { YaEvent } from '../../types/ya-event';
-import { YaReadyEvent } from '../../types/ya-ready-event';
+import type { YaEvent } from '../../types/ya-event';
+import type { YaReadyEvent } from '../../types/ya-ready-event';
 import { EventManager } from '../../utils/event-manager/event-manager';
 import { YaMapComponent } from '../ya-map/ya-map.component';
 

--- a/libs/angular-yandex-maps-v2/src/lib/components/ya-placemark/ya-placemark.directive.spec.ts
+++ b/libs/angular-yandex-maps-v2/src/lib/components/ya-placemark/ya-placemark.directive.spec.ts
@@ -1,5 +1,6 @@
 import { Component, ViewChild } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { BehaviorSubject } from 'rxjs';
 
 import {
@@ -7,7 +8,7 @@ import {
   mockPlacemarkConstructor,
   mockPlacemarkInstance,
 } from '../../../test-utils';
-import { YaReadyEvent } from '../../types/ya-ready-event';
+import type { YaReadyEvent } from '../../types/ya-ready-event';
 import { YaMapComponent } from '../ya-map/ya-map.component';
 import { YaPlacemarkDirective } from './ya-placemark.directive';
 

--- a/libs/angular-yandex-maps-v2/src/lib/components/ya-placemark/ya-placemark.directive.ts
+++ b/libs/angular-yandex-maps-v2/src/lib/components/ya-placemark/ya-placemark.directive.ts
@@ -1,20 +1,11 @@
-import {
-  Directive,
-  EventEmitter,
-  inject,
-  Input,
-  NgZone,
-  OnChanges,
-  OnDestroy,
-  OnInit,
-  Output,
-  SimpleChanges,
-} from '@angular/core';
-import { Observable, Subject, takeUntil } from 'rxjs';
+import type { OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
+import { Directive, EventEmitter, inject, Input, NgZone, Output } from '@angular/core';
+import type { Observable } from 'rxjs';
+import { Subject, takeUntil } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
-import { YaEvent } from '../../types/ya-event';
-import { YaReadyEvent } from '../../types/ya-ready-event';
+import type { YaEvent } from '../../types/ya-event';
+import type { YaReadyEvent } from '../../types/ya-ready-event';
 import { EventManager } from '../../utils/event-manager/event-manager';
 import { YaMapComponent } from '../ya-map/ya-map.component';
 

--- a/libs/angular-yandex-maps-v2/src/lib/services/ya-api-loader/ya-api-loader.service.spec.ts
+++ b/libs/angular-yandex-maps-v2/src/lib/services/ya-api-loader/ya-api-loader.service.spec.ts
@@ -1,10 +1,11 @@
 import { DOCUMENT, NgZone, PLATFORM_ID } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { combineLatest, mergeMap, NEVER, Observable, Subject, tap } from 'rxjs';
+import type { Observable } from 'rxjs';
+import { combineLatest, mergeMap, NEVER, Subject, tap } from 'rxjs';
 
 import { mockReady } from '../../../test-utils';
 import { YA_CONFIG } from '../../tokens/ya-config';
-import { YaConfig } from '../../types/ya-config';
+import type { YaConfig } from '../../types/ya-config';
 import { YaApiLoaderService } from './ya-api-loader.service';
 
 class FakeHTMLScriptElement implements Partial<HTMLScriptElement> {

--- a/libs/angular-yandex-maps-v2/src/lib/services/ya-api-loader/ya-api-loader.service.ts
+++ b/libs/angular-yandex-maps-v2/src/lib/services/ya-api-loader/ya-api-loader.service.ts
@@ -1,5 +1,6 @@
 import { isPlatformBrowser } from '@angular/common';
 import { DOCUMENT, inject, Injectable, NgZone, PLATFORM_ID } from '@angular/core';
+import type { Observable } from 'rxjs';
 import {
   BehaviorSubject,
   from,
@@ -8,7 +9,6 @@ import {
   merge,
   mergeMap,
   NEVER,
-  Observable,
   of,
   tap,
   throwError,
@@ -16,9 +16,9 @@ import {
 import { map, switchMap, take } from 'rxjs/operators';
 
 import { YA_CONFIG } from '../../tokens/ya-config';
-import { YaConfig } from '../../types/ya-config';
+import type { YaConfig } from '../../types/ya-config';
 import { exitZone } from '../../utils/zone/zone';
-import { YaApiLoaderCache } from './types/ya-api-loader-cache';
+import type { YaApiLoaderCache } from './types/ya-api-loader-cache';
 
 /**
  * The `YaApiLoader` service handles loading of Yandex.Maps API. Use it if you do not need `YaMapComponent`.

--- a/libs/angular-yandex-maps-v2/src/lib/services/ya-geocoder/ya-geocoder.service.ts
+++ b/libs/angular-yandex-maps-v2/src/lib/services/ya-geocoder/ya-geocoder.service.ts
@@ -1,5 +1,6 @@
 import { inject, Injectable, NgZone } from '@angular/core';
-import { from, Observable } from 'rxjs';
+import type { Observable } from 'rxjs';
+import { from } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 
 import { enterZone } from '../../utils/zone/zone';

--- a/libs/angular-yandex-maps-v2/src/lib/tokens/ya-config.ts
+++ b/libs/angular-yandex-maps-v2/src/lib/tokens/ya-config.ts
@@ -1,7 +1,7 @@
 import { InjectionToken, makeEnvironmentProviders } from '@angular/core';
-import { Observable } from 'rxjs';
+import type { Observable } from 'rxjs';
 
-import { YaConfig } from '../types/ya-config';
+import type { YaConfig } from '../types/ya-config';
 
 /**
  * @internal

--- a/libs/angular-yandex-maps-v2/src/lib/types/yandex-maps/index.ts
+++ b/libs/angular-yandex-maps-v2/src/lib/types/yandex-maps/index.ts
@@ -3894,8 +3894,7 @@ declare global {
     }
 
     interface IClustererOptions
-      extends IClustererOptionsInject,
-        IClusterPlacemarkOptionsWithClusterPrefix {
+      extends IClustererOptionsInject, IClusterPlacemarkOptionsWithClusterPrefix {
       hasBalloon?: boolean | undefined;
       hasHint?: boolean | undefined;
 
@@ -4008,9 +4007,10 @@ declare global {
       removeAll(): this;
     }
 
-    class Event<OriginalEvent = object, TargetGeometry = object>
-      implements IEvent<OriginalEvent, TargetGeometry>
-    {
+    class Event<OriginalEvent = object, TargetGeometry = object> implements IEvent<
+      OriginalEvent,
+      TargetGeometry
+    > {
       constructor(originalEvent: object, sourceEvent: IEvent);
 
       originalEvent: {
@@ -4047,9 +4047,10 @@ declare global {
       stopPropagation(): boolean;
     }
 
-    class DomEvent<OriginalEvent = object, TargetGeometry = object>
-      implements IDomEvent<OriginalEvent, TargetGeometry>
-    {
+    class DomEvent<OriginalEvent = object, TargetGeometry = object> implements IDomEvent<
+      OriginalEvent,
+      TargetGeometry
+    > {
       constructor(originalEvent: DomEvent, type?: object);
 
       originalEvent: {
@@ -4144,8 +4145,7 @@ declare global {
     }
 
     interface IGeoObjectOptions
-      extends IBalloonOptionsWithBalloonPrefix,
-        IHintOptionsWithHintPrefix {
+      extends IBalloonOptionsWithBalloonPrefix, IHintOptionsWithHintPrefix {
       circleOverlay?:
         | string
         | ((geometry: IPixelCircleGeometry, data: object, options: object) => Promise<IOverlay>);
@@ -4514,7 +4514,8 @@ declare global {
     }
 
     interface IPlacemarkOptions
-      extends layout.IImageOptionsWithIconPrefix,
+      extends
+        layout.IImageOptionsWithIconPrefix,
         layout.IImageWithContentOptionsWithIconPrefix,
         layout.IPieChartOptionsWithIconPrefix,
         IBalloonOptionsWithBalloonPrefix,
@@ -4710,8 +4711,7 @@ declare global {
     }
 
     interface IRectangleOptions
-      extends IBalloonOptionsWithBalloonPrefix,
-        IHintOptionsWithHintPrefix {
+      extends IBalloonOptionsWithBalloonPrefix, IHintOptionsWithHintPrefix {
       cursor?: string;
       draggable?: boolean;
       fill?: boolean;
@@ -5181,8 +5181,10 @@ declare global {
       stopPropagation(): boolean;
     }
 
-    interface IDomEvent<OriginalEvent = object, TargetGeometry = object>
-      extends IEvent<OriginalEvent, TargetGeometry> {
+    interface IDomEvent<OriginalEvent = object, TargetGeometry = object> extends IEvent<
+      OriginalEvent,
+      TargetGeometry
+    > {
       getSourceEvent(): IDomEvent<OriginalEvent, TargetGeometry>;
     }
 
@@ -5351,10 +5353,7 @@ declare global {
     }
 
     interface IGeoObject<T = IGeometry>
-      extends IChildOnMap,
-        ICustomizable,
-        IDomEventEmitter,
-        IParentOnMap {
+      extends IChildOnMap, ICustomizable, IDomEventEmitter, IParentOnMap {
       geometry: T | null;
 
       properties: IDataManager;
@@ -6078,7 +6077,8 @@ declare global {
     }
 
     interface IObjectManagerOptions
-      extends Omit<IClustererOptionsInject, 'hasBalloon' | 'hasHint'>,
+      extends
+        Omit<IClustererOptionsInject, 'hasBalloon' | 'hasHint'>,
         IClusterPlacemarkOptionsWithClusterPrefix,
         Omit<IGeoObjectOptionsWithGeoObjectPrefix, 'visible'> {
       clusterize?: boolean | undefined;
@@ -6135,7 +6135,8 @@ declare global {
     }
 
     interface ILoadingObjectManagerOptions
-      extends Omit<IClustererOptionsInject, 'hasBalloon' | 'hasHint'>,
+      extends
+        Omit<IClustererOptionsInject, 'hasBalloon' | 'hasHint'>,
         IClusterPlacemarkOptionsWithClusterPrefix,
         Omit<IGeoObjectOptionsWithGeoObjectPrefix, 'visible'> {
       clusterize?: boolean;
@@ -6329,8 +6330,7 @@ declare global {
     }
 
     interface IHotspotLayerOptions
-      extends IBalloonOptionsWithBalloonPrefix,
-        IHintOptionsWithHintPrefix {
+      extends IBalloonOptionsWithBalloonPrefix, IHintOptionsWithHintPrefix {
       cursor?: string;
       dontChangeCursor?: boolean;
       hasBalloon?: boolean;

--- a/libs/angular-yandex-maps-v2/src/lib/utils/event-manager/event-manager.spec.ts
+++ b/libs/angular-yandex-maps-v2/src/lib/utils/event-manager/event-manager.spec.ts
@@ -1,4 +1,4 @@
-import { NgZone } from '@angular/core';
+import type { NgZone } from '@angular/core';
 
 import { EventManager } from './event-manager';
 

--- a/libs/angular-yandex-maps-v2/src/lib/utils/event-manager/event-manager.ts
+++ b/libs/angular-yandex-maps-v2/src/lib/utils/event-manager/event-manager.ts
@@ -3,11 +3,12 @@
  * {@link https://github.com/angular/components/blob/main/src/google-maps/map-event-manager.ts}
  */
 
-import { NgZone } from '@angular/core';
-import { BehaviorSubject, Observable, Subscriber } from 'rxjs';
+import type { NgZone } from '@angular/core';
+import type { Subscriber } from 'rxjs';
+import { BehaviorSubject, Observable } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 
-import { YaEvent } from '../../types/ya-event';
+import type { YaEvent } from '../../types/ya-event';
 
 /**
  * @internal

--- a/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-clusterer/y-map-clusterer.directive.spec.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-clusterer/y-map-clusterer.directive.spec.ts
@@ -1,6 +1,7 @@
 import { Component, ViewChild } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { YMapClustererProps } from '@yandex/ymaps3-types/packages/clusterer';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
+import type { YMapClustererProps } from '@yandex/ymaps3-types/packages/clusterer';
 import { BehaviorSubject } from 'rxjs';
 
 import {
@@ -9,8 +10,8 @@ import {
   mockYMapClustererInstance,
   mockYMapInstance,
 } from '../../../../test-utils';
-import { Optional } from '../../../types/utilities/optional';
-import { YReadyEvent } from '../../../types/y-ready-event';
+import type { Optional } from '../../../types/utilities/optional';
+import type { YReadyEvent } from '../../../types/y-ready-event';
 import { YMapComponent } from '../y-map/y-map.component';
 import { YMapClustererDirective } from './y-map-clusterer.directive';
 

--- a/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-clusterer/y-map-clusterer.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-clusterer/y-map-clusterer.directive.ts
@@ -1,19 +1,21 @@
-import {
+import type {
   AfterContentInit,
+  OnChanges,
+  OnDestroy,
+  SimpleChanges,
+  TemplateRef,
+} from '@angular/core';
+import {
   ContentChild,
   Directive,
   EventEmitter,
   inject,
   Input,
   NgZone,
-  OnChanges,
-  OnDestroy,
   Output,
-  SimpleChanges,
-  TemplateRef,
 } from '@angular/core';
 import type { LngLat } from '@yandex/ymaps3-types/common/types';
-import {
+import type {
   Feature,
   YMapClusterer,
   YMapClustererProps,
@@ -21,8 +23,8 @@ import {
 import { from, Subject, takeUntil, tap } from 'rxjs';
 import { filter, switchMap } from 'rxjs/operators';
 
-import { Optional } from '../../../types/utilities/optional';
-import { YReadyEvent } from '../../../types/y-ready-event';
+import type { Optional } from '../../../types/utilities/optional';
+import type { YReadyEvent } from '../../../types/y-ready-event';
 import { YMapComponent } from '../y-map/y-map.component';
 
 /**

--- a/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-default-marker/y-map-default-marker.directive.spec.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-default-marker/y-map-default-marker.directive.spec.ts
@@ -1,15 +1,16 @@
 import { Component, ViewChild } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { YMapDefaultMarkerProps } from '@yandex/ymaps3-types/packages/markers';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
+import type { YMapDefaultMarkerProps } from '@yandex/ymaps3-types/packages/markers';
 import { BehaviorSubject } from 'rxjs';
 
+import type { mockYMapMarkerInstance } from '../../../../test-utils';
 import {
   mockYMapDefaultMarkerConstructor,
   mockYMapDefaultMarkerInstance,
   mockYMapInstance,
-  mockYMapMarkerInstance,
 } from '../../../../test-utils';
-import { YReadyEvent } from '../../../types/y-ready-event';
+import type { YReadyEvent } from '../../../types/y-ready-event';
 import { YMapComponent } from '../y-map/y-map.component';
 import { YMapDefaultMarkerDirective } from './y-map-default-marker.directive';
 

--- a/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-default-marker/y-map-default-marker.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-default-marker/y-map-default-marker.directive.ts
@@ -1,20 +1,13 @@
-import {
-  Directive,
-  EventEmitter,
-  inject,
-  Input,
-  NgZone,
-  OnChanges,
-  OnDestroy,
-  OnInit,
-  Output,
-  SimpleChanges,
-} from '@angular/core';
-import { YMapDefaultMarker, YMapDefaultMarkerProps } from '@yandex/ymaps3-types/packages/markers';
+import type { OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
+import { Directive, EventEmitter, inject, Input, NgZone, Output } from '@angular/core';
+import type {
+  YMapDefaultMarker,
+  YMapDefaultMarkerProps,
+} from '@yandex/ymaps3-types/packages/markers';
 import { from, Subject, takeUntil, tap } from 'rxjs';
 import { filter, switchMap } from 'rxjs/operators';
 
-import { YReadyEvent } from '../../../types/y-ready-event';
+import type { YReadyEvent } from '../../../types/y-ready-event';
 import { YMapComponent } from '../y-map/y-map.component';
 
 /**

--- a/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-feature-data-source/y-map-feature-data-source.directive.spec.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-feature-data-source/y-map-feature-data-source.directive.spec.ts
@@ -1,6 +1,7 @@
 import { Component, ViewChild } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { YMapFeatureDataSourceProps } from '@yandex/ymaps3-types';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
+import type { YMapFeatureDataSourceProps } from '@yandex/ymaps3-types';
 import { BehaviorSubject } from 'rxjs';
 
 import {
@@ -8,7 +9,7 @@ import {
   mockYMapFeatureDataSourceInstance,
   mockYMapInstance,
 } from '../../../../test-utils';
-import { YReadyEvent } from '../../../types/y-ready-event';
+import type { YReadyEvent } from '../../../types/y-ready-event';
 import { YMapComponent } from '../y-map/y-map.component';
 import { YMapFeatureDataSourceDirective } from './y-map-feature-data-source.directive';
 

--- a/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-feature-data-source/y-map-feature-data-source.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-feature-data-source/y-map-feature-data-source.directive.ts
@@ -1,20 +1,10 @@
-import {
-  Directive,
-  EventEmitter,
-  inject,
-  Input,
-  NgZone,
-  OnChanges,
-  OnDestroy,
-  OnInit,
-  Output,
-  SimpleChanges,
-} from '@angular/core';
-import { YMapFeatureDataSource, YMapFeatureDataSourceProps } from '@yandex/ymaps3-types';
+import type { OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
+import { Directive, EventEmitter, inject, Input, NgZone, Output } from '@angular/core';
+import type { YMapFeatureDataSource, YMapFeatureDataSourceProps } from '@yandex/ymaps3-types';
 import { Subject, takeUntil } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
-import { YReadyEvent } from '../../../types/y-ready-event';
+import type { YReadyEvent } from '../../../types/y-ready-event';
 import { YMapComponent } from '../y-map/y-map.component';
 
 /**

--- a/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-feature/y-map-feature.directive.spec.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-feature/y-map-feature.directive.spec.ts
@@ -1,6 +1,7 @@
 import { Component, ViewChild } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { YMapFeatureProps } from '@yandex/ymaps3-types';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
+import type { YMapFeatureProps } from '@yandex/ymaps3-types';
 import { BehaviorSubject } from 'rxjs';
 
 import {
@@ -8,7 +9,7 @@ import {
   mockYMapFeatureInstance,
   mockYMapInstance,
 } from '../../../../test-utils';
-import { YReadyEvent } from '../../../types/y-ready-event';
+import type { YReadyEvent } from '../../../types/y-ready-event';
 import { YMapComponent } from '../y-map/y-map.component';
 import { YMapFeatureDirective } from './y-map-feature.directive';
 

--- a/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-feature/y-map-feature.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-feature/y-map-feature.directive.ts
@@ -1,20 +1,10 @@
-import {
-  Directive,
-  EventEmitter,
-  inject,
-  Input,
-  NgZone,
-  OnChanges,
-  OnDestroy,
-  OnInit,
-  Output,
-  SimpleChanges,
-} from '@angular/core';
-import { YMapFeature, YMapFeatureProps } from '@yandex/ymaps3-types';
+import type { OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
+import { Directive, EventEmitter, inject, Input, NgZone, Output } from '@angular/core';
+import type { YMapFeature, YMapFeatureProps } from '@yandex/ymaps3-types';
 import { Subject, takeUntil } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
-import { YReadyEvent } from '../../../types/y-ready-event';
+import type { YReadyEvent } from '../../../types/y-ready-event';
 import { YMapComponent } from '../y-map/y-map.component';
 
 /**

--- a/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-hint/y-map-hint.directive.spec.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-hint/y-map-hint.directive.spec.ts
@@ -1,5 +1,6 @@
 import { Component, ViewChild } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { BehaviorSubject } from 'rxjs';
 
 import {
@@ -11,8 +12,8 @@ import {
   mockYMapHintInstance,
   mockYMapInstance,
 } from '../../../../test-utils';
-import { YMapHintProps } from '../../../types/y-map-hint-props';
-import { YReadyEvent } from '../../../types/y-ready-event';
+import type { YMapHintProps } from '../../../types/y-map-hint-props';
+import type { YReadyEvent } from '../../../types/y-ready-event';
 import { YMapComponent } from '../y-map/y-map.component';
 import { YMapHintDirective } from './y-map-hint.directive';
 

--- a/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-hint/y-map-hint.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-hint/y-map-hint.directive.ts
@@ -1,24 +1,21 @@
+import type { AfterContentInit, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
 import {
-  AfterContentInit,
   ContentChild,
   Directive,
   EventEmitter,
   inject,
   Input,
   NgZone,
-  OnChanges,
-  OnDestroy,
   Output,
-  SimpleChanges,
   TemplateRef,
 } from '@angular/core';
-import { DomDetach } from '@yandex/ymaps3-types/imperative/DomContext';
-import { YMapHint, YMapHintContext } from '@yandex/ymaps3-types/packages/hint';
+import type { DomDetach } from '@yandex/ymaps3-types/imperative/DomContext';
+import type { YMapHint, YMapHintContext } from '@yandex/ymaps3-types/packages/hint';
 import { from, Subject, takeUntil, tap } from 'rxjs';
 import { filter, switchMap } from 'rxjs/operators';
 
-import { YMapHintProps } from '../../../types/y-map-hint-props';
-import { YReadyEvent } from '../../../types/y-ready-event';
+import type { YMapHintProps } from '../../../types/y-map-hint-props';
+import type { YReadyEvent } from '../../../types/y-ready-event';
 import { YMapComponent } from '../y-map/y-map.component';
 
 /**

--- a/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-listener/y-map-listener.directive.spec.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-listener/y-map-listener.directive.spec.ts
@@ -1,6 +1,7 @@
 import { Component, ViewChild } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { YMapListenerProps } from '@yandex/ymaps3-types';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
+import type { YMapListenerProps } from '@yandex/ymaps3-types';
 import { BehaviorSubject } from 'rxjs';
 
 import {
@@ -8,7 +9,7 @@ import {
   mockYMapListenerConstructor,
   mockYMapListenerInstance,
 } from '../../../../test-utils';
-import { YReadyEvent } from '../../../types/y-ready-event';
+import type { YReadyEvent } from '../../../types/y-ready-event';
 import { YMapComponent } from '../y-map/y-map.component';
 import { YMapListenerDirective } from './y-map-listener.directive';
 

--- a/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-listener/y-map-listener.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-listener/y-map-listener.directive.ts
@@ -1,20 +1,10 @@
-import {
-  Directive,
-  EventEmitter,
-  inject,
-  Input,
-  NgZone,
-  OnChanges,
-  OnDestroy,
-  OnInit,
-  Output,
-  SimpleChanges,
-} from '@angular/core';
-import { YMapListener, YMapListenerProps } from '@yandex/ymaps3-types';
+import type { OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
+import { Directive, EventEmitter, inject, Input, NgZone, Output } from '@angular/core';
+import type { YMapListener, YMapListenerProps } from '@yandex/ymaps3-types';
 import { Subject, takeUntil } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
-import { YReadyEvent } from '../../../types/y-ready-event';
+import type { YReadyEvent } from '../../../types/y-ready-event';
 import { YMapComponent } from '../y-map/y-map.component';
 
 /**

--- a/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-marker/y-map-marker.directive.spec.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-marker/y-map-marker.directive.spec.ts
@@ -1,6 +1,8 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { YMapMarkerProps } from '@yandex/ymaps3-types';
+import type { ElementRef } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
+import type { YMapMarkerProps } from '@yandex/ymaps3-types';
 import { BehaviorSubject } from 'rxjs';
 
 import {
@@ -8,7 +10,7 @@ import {
   mockYMapMarkerConstructor,
   mockYMapMarkerInstance,
 } from '../../../../test-utils';
-import { YReadyEvent } from '../../../types/y-ready-event';
+import type { YReadyEvent } from '../../../types/y-ready-event';
 import { YMapComponent } from '../y-map/y-map.component';
 import { YMapMarkerDirective } from './y-map-marker.directive';
 

--- a/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-marker/y-map-marker.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/common/y-map-marker/y-map-marker.directive.ts
@@ -1,21 +1,10 @@
-import {
-  AfterViewInit,
-  Directive,
-  ElementRef,
-  EventEmitter,
-  inject,
-  Input,
-  NgZone,
-  OnChanges,
-  OnDestroy,
-  Output,
-  SimpleChanges,
-} from '@angular/core';
-import { YMapMarker, YMapMarkerProps } from '@yandex/ymaps3-types';
+import type { AfterViewInit, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
+import { Directive, ElementRef, EventEmitter, inject, Input, NgZone, Output } from '@angular/core';
+import type { YMapMarker, YMapMarkerProps } from '@yandex/ymaps3-types';
 import { Subject, takeUntil } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
-import { YReadyEvent } from '../../../types/y-ready-event';
+import type { YReadyEvent } from '../../../types/y-ready-event';
 import { YMapComponent } from '../y-map/y-map.component';
 
 /**

--- a/libs/angular-yandex-maps-v3/src/lib/components/common/y-map/y-map.component.spec.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/common/y-map/y-map.component.spec.ts
@@ -1,12 +1,14 @@
 import { Component, ViewChild } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { YMapEntity, YMapProps } from '@yandex/ymaps3-types';
-import { BehaviorSubject, Subject } from 'rxjs';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
+import type { YMapEntity, YMapProps } from '@yandex/ymaps3-types';
+import type { Subject } from 'rxjs';
+import { BehaviorSubject } from 'rxjs';
 
 import { mockYMapConstructor, mockYMapInstance } from '../../../../test-utils';
 import { YApiLoaderService } from '../../../services/y-api-loader/y-api-loader.service';
-import { YConfig } from '../../../types/y-config';
-import { YReadyEvent } from '../../../types/y-ready-event';
+import type { YConfig } from '../../../types/y-config';
+import type { YReadyEvent } from '../../../types/y-ready-event';
 import * as GenerateRandomIdModule from '../../../utils/generate-random-id/generate-random-id';
 import { YMapComponent } from './y-map.component';
 

--- a/libs/angular-yandex-maps-v3/src/lib/components/common/y-map/y-map.component.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/common/y-map/y-map.component.ts
@@ -1,23 +1,19 @@
+import type { AfterViewInit, ElementRef, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
 import {
-  AfterViewInit,
   ChangeDetectionStrategy,
   Component,
-  ElementRef,
   EventEmitter,
   inject,
   Input,
   NgZone,
-  OnChanges,
-  OnDestroy,
   Output,
-  SimpleChanges,
   ViewChild,
 } from '@angular/core';
-import { YMap, YMapEntity, YMapProps } from '@yandex/ymaps3-types';
+import type { YMap, YMapEntity, YMapProps } from '@yandex/ymaps3-types';
 import { BehaviorSubject, Subject, takeUntil } from 'rxjs';
 
 import { YApiLoaderService } from '../../../services/y-api-loader/y-api-loader.service';
-import { YReadyEvent } from '../../../types/y-ready-event';
+import type { YReadyEvent } from '../../../types/y-ready-event';
 import { generateRandomId } from '../../../utils/generate-random-id/generate-random-id';
 
 /**

--- a/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-control-button/y-map-control-button.directive.spec.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-control-button/y-map-control-button.directive.spec.ts
@@ -1,7 +1,8 @@
 import { Component, ViewChild } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { YMap } from '@yandex/ymaps3-types';
-import { YMapControlCommonButtonProps } from '@yandex/ymaps3-types/imperative/YMapControl';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
+import type { YMap } from '@yandex/ymaps3-types';
+import type { YMapControlCommonButtonProps } from '@yandex/ymaps3-types/imperative/YMapControl';
 import { BehaviorSubject } from 'rxjs';
 
 import {
@@ -9,8 +10,8 @@ import {
   mockYMapControlButtonInstance,
   mockYMapControlsInstance,
 } from '../../../../test-utils';
-import { ComplexOptions } from '../../../types/complex-options';
-import { YReadyEvent } from '../../../types/y-ready-event';
+import type { ComplexOptions } from '../../../types/complex-options';
+import type { YReadyEvent } from '../../../types/y-ready-event';
 import { YMapControlsDirective } from '../y-map-controls/y-map-controls.directive';
 import { YMapControlButtonDirective } from './y-map-control-button.directive';
 

--- a/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-control-button/y-map-control-button.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-control-button/y-map-control-button.directive.ts
@@ -1,22 +1,12 @@
-import {
-  Directive,
-  EventEmitter,
-  inject,
-  Input,
-  NgZone,
-  OnChanges,
-  OnDestroy,
-  OnInit,
-  Output,
-  SimpleChanges,
-} from '@angular/core';
-import { YMap, YMapControlButton } from '@yandex/ymaps3-types';
-import { YMapControlCommonButtonProps } from '@yandex/ymaps3-types/imperative/YMapControl';
+import type { OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
+import { Directive, EventEmitter, inject, Input, NgZone, Output } from '@angular/core';
+import type { YMap, YMapControlButton } from '@yandex/ymaps3-types';
+import type { YMapControlCommonButtonProps } from '@yandex/ymaps3-types/imperative/YMapControl';
 import { Subject, takeUntil } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
-import { ComplexOptions } from '../../../types/complex-options';
-import { YReadyEvent } from '../../../types/y-ready-event';
+import type { ComplexOptions } from '../../../types/complex-options';
+import type { YReadyEvent } from '../../../types/y-ready-event';
 import { YMapControlsDirective } from '../y-map-controls/y-map-controls.directive';
 
 /**

--- a/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-control-common-button/y-map-control-common-button.directive.spec.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-control-common-button/y-map-control-common-button.directive.spec.ts
@@ -1,7 +1,8 @@
 import { Component, ViewChild } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { YMap } from '@yandex/ymaps3-types';
-import { YMapControlCommonButtonProps } from '@yandex/ymaps3-types/imperative/YMapControl';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
+import type { YMap } from '@yandex/ymaps3-types';
+import type { YMapControlCommonButtonProps } from '@yandex/ymaps3-types/imperative/YMapControl';
 import { BehaviorSubject } from 'rxjs';
 
 import {
@@ -9,8 +10,8 @@ import {
   mockYMapControlCommonButtonInstance,
   mockYMapControlsInstance,
 } from '../../../../test-utils';
-import { ComplexOptions } from '../../../types/complex-options';
-import { YReadyEvent } from '../../../types/y-ready-event';
+import type { ComplexOptions } from '../../../types/complex-options';
+import type { YReadyEvent } from '../../../types/y-ready-event';
 import { YMapControlsDirective } from '../y-map-controls/y-map-controls.directive';
 import { YMapControlCommonButtonDirective } from './y-map-control-common-button.directive';
 

--- a/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-control-common-button/y-map-control-common-button.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-control-common-button/y-map-control-common-button.directive.ts
@@ -1,25 +1,15 @@
-import {
-  Directive,
-  EventEmitter,
-  inject,
-  Input,
-  NgZone,
-  OnChanges,
-  OnDestroy,
-  OnInit,
-  Output,
-  SimpleChanges,
-} from '@angular/core';
-import { YMap } from '@yandex/ymaps3-types';
-import {
+import type { OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
+import { Directive, EventEmitter, inject, Input, NgZone, Output } from '@angular/core';
+import type { YMap } from '@yandex/ymaps3-types';
+import type {
   YMapControlCommonButton,
   YMapControlCommonButtonProps,
 } from '@yandex/ymaps3-types/imperative/YMapControl';
 import { Subject, takeUntil } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
-import { ComplexOptions } from '../../../types/complex-options';
-import { YReadyEvent } from '../../../types/y-ready-event';
+import type { ComplexOptions } from '../../../types/complex-options';
+import type { YReadyEvent } from '../../../types/y-ready-event';
 import { YMapControlsDirective } from '../y-map-controls/y-map-controls.directive';
 
 /**

--- a/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-control/y-map-control.directive.spec.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-control/y-map-control.directive.spec.ts
@@ -1,6 +1,8 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { YMapControlProps } from '@yandex/ymaps3-types/imperative/YMapControl';
+import type { ElementRef } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
+import type { YMapControlProps } from '@yandex/ymaps3-types/imperative/YMapControl';
 import { BehaviorSubject } from 'rxjs';
 
 import {
@@ -10,7 +12,7 @@ import {
   mockYMapGroupEntityConstructor,
   mockYMapGroupEntityInstance,
 } from '../../../../test-utils';
-import { YReadyEvent } from '../../../types/y-ready-event';
+import type { YReadyEvent } from '../../../types/y-ready-event';
 import { YMapControlsDirective } from '../y-map-controls/y-map-controls.directive';
 import { YMapControlDirective } from './y-map-control.directive';
 

--- a/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-control/y-map-control.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-control/y-map-control.directive.ts
@@ -1,22 +1,11 @@
-import {
-  AfterViewInit,
-  Directive,
-  ElementRef,
-  EventEmitter,
-  inject,
-  Input,
-  NgZone,
-  OnChanges,
-  OnDestroy,
-  Output,
-  SimpleChanges,
-} from '@angular/core';
-import { DomDetach } from '@yandex/ymaps3-types/imperative/DomContext';
-import { YMapControl, YMapControlProps } from '@yandex/ymaps3-types/imperative/YMapControl';
+import type { AfterViewInit, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
+import { Directive, ElementRef, EventEmitter, inject, Input, NgZone, Output } from '@angular/core';
+import type { DomDetach } from '@yandex/ymaps3-types/imperative/DomContext';
+import type { YMapControl, YMapControlProps } from '@yandex/ymaps3-types/imperative/YMapControl';
 import { Subject, takeUntil } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
-import { YReadyEvent } from '../../../types/y-ready-event';
+import type { YReadyEvent } from '../../../types/y-ready-event';
 import { YMapControlsDirective } from '../y-map-controls/y-map-controls.directive';
 
 /**

--- a/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-controls/y-map-controls.directive.spec.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-controls/y-map-controls.directive.spec.ts
@@ -1,6 +1,7 @@
 import { Component, ViewChild } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { YMapControlsProps, YMapEntity } from '@yandex/ymaps3-types';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
+import type { YMapControlsProps, YMapEntity } from '@yandex/ymaps3-types';
 import { BehaviorSubject } from 'rxjs';
 
 import {
@@ -8,7 +9,7 @@ import {
   mockYMapControlsInstance,
   mockYMapInstance,
 } from '../../../../test-utils';
-import { YReadyEvent } from '../../../types/y-ready-event';
+import type { YReadyEvent } from '../../../types/y-ready-event';
 import { YMapComponent } from '../../common/y-map/y-map.component';
 import { YMapControlsDirective } from './y-map-controls.directive';
 

--- a/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-controls/y-map-controls.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-controls/y-map-controls.directive.ts
@@ -1,20 +1,10 @@
-import {
-  Directive,
-  EventEmitter,
-  inject,
-  Input,
-  NgZone,
-  OnChanges,
-  OnDestroy,
-  OnInit,
-  Output,
-  SimpleChanges,
-} from '@angular/core';
-import { YMapControls, YMapControlsProps, YMapEntity } from '@yandex/ymaps3-types';
+import type { OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
+import { Directive, EventEmitter, inject, Input, NgZone, Output } from '@angular/core';
+import type { YMapControls, YMapControlsProps, YMapEntity } from '@yandex/ymaps3-types';
 import { BehaviorSubject, Subject, takeUntil } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
-import { YReadyEvent } from '../../../types/y-ready-event';
+import type { YReadyEvent } from '../../../types/y-ready-event';
 import { YMapComponent } from '../../common/y-map/y-map.component';
 
 /**

--- a/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-geolocation-control/y-map-geolocation-control.directive.spec.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-geolocation-control/y-map-geolocation-control.directive.spec.ts
@@ -1,6 +1,7 @@
 import { Component, ViewChild } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { YMapGeolocationControlProps } from '@yandex/ymaps3-types/packages/controls';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
+import type { YMapGeolocationControlProps } from '@yandex/ymaps3-types/packages/controls';
 import { BehaviorSubject } from 'rxjs';
 
 import {
@@ -8,7 +9,7 @@ import {
   mockYMapGeolocationControlConstructor,
   mockYMapGeolocationControlInstance,
 } from '../../../../test-utils';
-import { YReadyEvent } from '../../../types/y-ready-event';
+import type { YReadyEvent } from '../../../types/y-ready-event';
 import { YMapControlsDirective } from '../y-map-controls/y-map-controls.directive';
 import { YMapGeolocationControlDirective } from './y-map-geolocation-control.directive';
 

--- a/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-geolocation-control/y-map-geolocation-control.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-geolocation-control/y-map-geolocation-control.directive.ts
@@ -1,23 +1,13 @@
-import {
-  Directive,
-  EventEmitter,
-  inject,
-  Input,
-  NgZone,
-  OnChanges,
-  OnDestroy,
-  OnInit,
-  Output,
-  SimpleChanges,
-} from '@angular/core';
-import {
+import type { OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
+import { Directive, EventEmitter, inject, Input, NgZone, Output } from '@angular/core';
+import type {
   YMapGeolocationControl,
   YMapGeolocationControlProps,
 } from '@yandex/ymaps3-types/packages/controls';
 import { from, Subject, takeUntil, tap } from 'rxjs';
 import { filter, switchMap } from 'rxjs/operators';
 
-import { YReadyEvent } from '../../../types/y-ready-event';
+import type { YReadyEvent } from '../../../types/y-ready-event';
 import { YMapControlsDirective } from '../y-map-controls/y-map-controls.directive';
 
 /**

--- a/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-open-maps-button/y-map-open-maps-button.directive.spec.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-open-maps-button/y-map-open-maps-button.directive.spec.ts
@@ -1,6 +1,7 @@
 import { Component, ViewChild } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { YMapOpenMapsButtonProps } from '@yandex/ymaps3-types/modules/controls-extra';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
+import type { YMapOpenMapsButtonProps } from '@yandex/ymaps3-types/modules/controls-extra';
 import { BehaviorSubject } from 'rxjs';
 
 import {
@@ -8,7 +9,7 @@ import {
   mockYMapOpenMapsButtonConstructor,
   mockYMapOpenMapsButtonInstance,
 } from '../../../../test-utils';
-import { YReadyEvent } from '../../../types/y-ready-event';
+import type { YReadyEvent } from '../../../types/y-ready-event';
 import { YMapControlsDirective } from '../y-map-controls/y-map-controls.directive';
 import { YMapOpenMapsButtonDirective } from './y-map-open-maps-button.directive';
 

--- a/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-open-maps-button/y-map-open-maps-button.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-open-maps-button/y-map-open-maps-button.directive.ts
@@ -1,23 +1,13 @@
-import {
-  Directive,
-  EventEmitter,
-  inject,
-  Input,
-  NgZone,
-  OnChanges,
-  OnDestroy,
-  OnInit,
-  Output,
-  SimpleChanges,
-} from '@angular/core';
-import {
+import type { OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
+import { Directive, EventEmitter, inject, Input, NgZone, Output } from '@angular/core';
+import type {
   YMapOpenMapsButton,
   YMapOpenMapsButtonProps,
 } from '@yandex/ymaps3-types/modules/controls-extra';
 import { from, Subject, takeUntil, tap } from 'rxjs';
 import { filter, switchMap } from 'rxjs/operators';
 
-import { YReadyEvent } from '../../../types/y-ready-event';
+import type { YReadyEvent } from '../../../types/y-ready-event';
 import { YMapControlsDirective } from '../y-map-controls/y-map-controls.directive';
 
 /**

--- a/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-scale-control/y-map-scale-control.directive.spec.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-scale-control/y-map-scale-control.directive.spec.ts
@@ -1,15 +1,16 @@
 import { Component, ViewChild } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { YMapScaleControlProps } from '@yandex/ymaps3-types';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
+import type { YMapScaleControlProps } from '@yandex/ymaps3-types';
 import { BehaviorSubject } from 'rxjs';
 
+import type { mockYMapControlButtonInstance } from '../../../../test-utils';
 import {
-  mockYMapControlButtonInstance,
   mockYMapControlsInstance,
   mockYMapScaleControlConstructor,
   mockYMapScaleControlInstance,
 } from '../../../../test-utils';
-import { YReadyEvent } from '../../../types/y-ready-event';
+import type { YReadyEvent } from '../../../types/y-ready-event';
 import { YMapControlsDirective } from '../y-map-controls/y-map-controls.directive';
 import { YMapScaleControlDirective } from './y-map-scale-control.directive';
 

--- a/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-scale-control/y-map-scale-control.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-scale-control/y-map-scale-control.directive.ts
@@ -1,20 +1,10 @@
-import {
-  Directive,
-  EventEmitter,
-  inject,
-  Input,
-  NgZone,
-  OnChanges,
-  OnDestroy,
-  OnInit,
-  Output,
-  SimpleChanges,
-} from '@angular/core';
-import { YMapScaleControl, YMapScaleControlProps } from '@yandex/ymaps3-types';
+import type { OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
+import { Directive, EventEmitter, inject, Input, NgZone, Output } from '@angular/core';
+import type { YMapScaleControl, YMapScaleControlProps } from '@yandex/ymaps3-types';
 import { Subject, takeUntil } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
-import { YReadyEvent } from '../../../types/y-ready-event';
+import type { YReadyEvent } from '../../../types/y-ready-event';
 import { YMapControlsDirective } from '../y-map-controls/y-map-controls.directive';
 
 /**

--- a/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-zoom-control/y-map-zoom-control.directive.spec.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-zoom-control/y-map-zoom-control.directive.spec.ts
@@ -1,7 +1,8 @@
 import { Component, ViewChild } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { YMap } from '@yandex/ymaps3-types';
-import { YMapZoomControlProps } from '@yandex/ymaps3-types/packages/controls';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
+import type { YMap } from '@yandex/ymaps3-types';
+import type { YMapZoomControlProps } from '@yandex/ymaps3-types/packages/controls';
 import { BehaviorSubject } from 'rxjs';
 
 import {
@@ -9,8 +10,8 @@ import {
   mockYMapZoomControlConstructor,
   mockYMapZoomControlInstance,
 } from '../../../../test-utils';
-import { ComplexOptions } from '../../../types/complex-options';
-import { YReadyEvent } from '../../../types/y-ready-event';
+import type { ComplexOptions } from '../../../types/complex-options';
+import type { YReadyEvent } from '../../../types/y-ready-event';
 import { YMapControlsDirective } from '../y-map-controls/y-map-controls.directive';
 import { YMapZoomControlDirective } from './y-map-zoom-control.directive';
 

--- a/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-zoom-control/y-map-zoom-control.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/controls/y-map-zoom-control/y-map-zoom-control.directive.ts
@@ -1,22 +1,12 @@
-import {
-  Directive,
-  EventEmitter,
-  inject,
-  Input,
-  NgZone,
-  OnChanges,
-  OnDestroy,
-  OnInit,
-  Output,
-  SimpleChanges,
-} from '@angular/core';
-import { YMap } from '@yandex/ymaps3-types';
-import { YMapZoomControl, YMapZoomControlProps } from '@yandex/ymaps3-types/packages/controls';
+import type { OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
+import { Directive, EventEmitter, inject, Input, NgZone, Output } from '@angular/core';
+import type { YMap } from '@yandex/ymaps3-types';
+import type { YMapZoomControl, YMapZoomControlProps } from '@yandex/ymaps3-types/packages/controls';
 import { from, Subject, takeUntil, tap } from 'rxjs';
 import { filter, switchMap } from 'rxjs/operators';
 
-import { ComplexOptions } from '../../../types/complex-options';
-import { YReadyEvent } from '../../../types/y-ready-event';
+import type { ComplexOptions } from '../../../types/complex-options';
+import type { YReadyEvent } from '../../../types/y-ready-event';
 import { YMapControlsDirective } from '../y-map-controls/y-map-controls.directive';
 
 /**

--- a/libs/angular-yandex-maps-v3/src/lib/components/layers/y-map-default-features-layer/y-map-default-features-layer.directive.spec.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/layers/y-map-default-features-layer/y-map-default-features-layer.directive.spec.ts
@@ -1,6 +1,7 @@
 import { Component, ViewChild } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { YMap, YMapDefaultFeaturesLayerProps } from '@yandex/ymaps3-types';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
+import type { YMap, YMapDefaultFeaturesLayerProps } from '@yandex/ymaps3-types';
 import { BehaviorSubject } from 'rxjs';
 
 import {
@@ -8,8 +9,8 @@ import {
   mockYMapDefaultFeaturesLayerInstance,
   mockYMapInstance,
 } from '../../../../test-utils';
-import { ComplexOptions } from '../../../types/complex-options';
-import { YReadyEvent } from '../../../types/y-ready-event';
+import type { ComplexOptions } from '../../../types/complex-options';
+import type { YReadyEvent } from '../../../types/y-ready-event';
 import { YMapComponent } from '../../common/y-map/y-map.component';
 import { YMapDefaultFeaturesLayerDirective } from './y-map-default-features-layer.directive';
 

--- a/libs/angular-yandex-maps-v3/src/lib/components/layers/y-map-default-features-layer/y-map-default-features-layer.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/layers/y-map-default-features-layer/y-map-default-features-layer.directive.ts
@@ -1,16 +1,6 @@
-import {
-  Directive,
-  EventEmitter,
-  inject,
-  Input,
-  NgZone,
-  OnChanges,
-  OnDestroy,
-  OnInit,
-  Output,
-  SimpleChanges,
-} from '@angular/core';
-import {
+import type { OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
+import { Directive, EventEmitter, inject, Input, NgZone, Output } from '@angular/core';
+import type {
   YMap,
   YMapDefaultFeaturesLayer,
   YMapDefaultFeaturesLayerProps,
@@ -18,8 +8,8 @@ import {
 import { Subject, takeUntil } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
-import { ComplexOptions } from '../../../types/complex-options';
-import { YReadyEvent } from '../../../types/y-ready-event';
+import type { ComplexOptions } from '../../../types/complex-options';
+import type { YReadyEvent } from '../../../types/y-ready-event';
 import { YMapComponent } from '../../common/y-map/y-map.component';
 
 /**

--- a/libs/angular-yandex-maps-v3/src/lib/components/layers/y-map-default-scheme-layer/y-map-default-scheme-layer.directive.spec.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/layers/y-map-default-scheme-layer/y-map-default-scheme-layer.directive.spec.ts
@@ -1,6 +1,7 @@
 import { Component, ViewChild } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { YMap, YMapDefaultSchemeLayerProps } from '@yandex/ymaps3-types';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
+import type { YMap, YMapDefaultSchemeLayerProps } from '@yandex/ymaps3-types';
 import { BehaviorSubject } from 'rxjs';
 
 import {
@@ -8,8 +9,8 @@ import {
   mockYMapDefaultSchemeLayerInstance,
   mockYMapInstance,
 } from '../../../../test-utils';
-import { ComplexOptions } from '../../../types/complex-options';
-import { YReadyEvent } from '../../../types/y-ready-event';
+import type { ComplexOptions } from '../../../types/complex-options';
+import type { YReadyEvent } from '../../../types/y-ready-event';
 import { YMapComponent } from '../../common/y-map/y-map.component';
 import { YMapDefaultSchemeLayerDirective } from './y-map-default-scheme-layer.directive';
 

--- a/libs/angular-yandex-maps-v3/src/lib/components/layers/y-map-default-scheme-layer/y-map-default-scheme-layer.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/layers/y-map-default-scheme-layer/y-map-default-scheme-layer.directive.ts
@@ -1,21 +1,15 @@
-import {
-  Directive,
-  EventEmitter,
-  inject,
-  Input,
-  NgZone,
-  OnChanges,
-  OnDestroy,
-  OnInit,
-  Output,
-  SimpleChanges,
-} from '@angular/core';
-import { YMap, YMapDefaultSchemeLayer, YMapDefaultSchemeLayerProps } from '@yandex/ymaps3-types';
+import type { OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
+import { Directive, EventEmitter, inject, Input, NgZone, Output } from '@angular/core';
+import type {
+  YMap,
+  YMapDefaultSchemeLayer,
+  YMapDefaultSchemeLayerProps,
+} from '@yandex/ymaps3-types';
 import { Subject, takeUntil } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
-import { ComplexOptions } from '../../../types/complex-options';
-import { YReadyEvent } from '../../../types/y-ready-event';
+import type { ComplexOptions } from '../../../types/complex-options';
+import type { YReadyEvent } from '../../../types/y-ready-event';
 import { YMapComponent } from '../../common/y-map/y-map.component';
 
 /**

--- a/libs/angular-yandex-maps-v3/src/lib/components/layers/y-map-layer/y-map-layer.directive.spec.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/layers/y-map-layer/y-map-layer.directive.spec.ts
@@ -1,6 +1,7 @@
 import { Component, ViewChild } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { YMapLayerProps } from '@yandex/ymaps3-types';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
+import type { YMapLayerProps } from '@yandex/ymaps3-types';
 import { BehaviorSubject } from 'rxjs';
 
 import {
@@ -8,7 +9,7 @@ import {
   mockYMapLayerConstructor,
   mockYMapLayerInstance,
 } from '../../../../test-utils';
-import { YReadyEvent } from '../../../types/y-ready-event';
+import type { YReadyEvent } from '../../../types/y-ready-event';
 import { YMapComponent } from '../../common/y-map/y-map.component';
 import { YMapLayerDirective } from './y-map-layer.directive';
 

--- a/libs/angular-yandex-maps-v3/src/lib/components/layers/y-map-layer/y-map-layer.directive.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/components/layers/y-map-layer/y-map-layer.directive.ts
@@ -1,20 +1,10 @@
-import {
-  Directive,
-  EventEmitter,
-  inject,
-  Input,
-  NgZone,
-  OnChanges,
-  OnDestroy,
-  OnInit,
-  Output,
-  SimpleChanges,
-} from '@angular/core';
-import { YMapLayer, YMapLayerProps } from '@yandex/ymaps3-types';
+import type { OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
+import { Directive, EventEmitter, inject, Input, NgZone, Output } from '@angular/core';
+import type { YMapLayer, YMapLayerProps } from '@yandex/ymaps3-types';
 import { Subject, takeUntil } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
-import { YReadyEvent } from '../../../types/y-ready-event';
+import type { YReadyEvent } from '../../../types/y-ready-event';
 import { YMapComponent } from '../../common/y-map/y-map.component';
 
 /**

--- a/libs/angular-yandex-maps-v3/src/lib/services/y-api-loader/y-api-loader.service.spec.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/services/y-api-loader/y-api-loader.service.spec.ts
@@ -1,10 +1,11 @@
 import { DOCUMENT, NgZone, PLATFORM_ID } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { combineLatest, mergeMap, NEVER, Observable, Subject, tap } from 'rxjs';
+import type { Observable } from 'rxjs';
+import { combineLatest, mergeMap, NEVER, Subject, tap } from 'rxjs';
 
 import { mockImport, mockReady } from '../../../test-utils';
 import { Y_CONFIG } from '../../tokens/y-config';
-import { YConfig } from '../../types/y-config';
+import type { YConfig } from '../../types/y-config';
 import { YApiLoaderService } from './y-api-loader.service';
 
 class FakeHTMLScriptElement implements Partial<HTMLScriptElement> {

--- a/libs/angular-yandex-maps-v3/src/lib/services/y-api-loader/y-api-loader.service.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/services/y-api-loader/y-api-loader.service.ts
@@ -1,5 +1,6 @@
 import { isPlatformBrowser } from '@angular/common';
 import { DOCUMENT, inject, Injectable, NgZone, PLATFORM_ID } from '@angular/core';
+import type { Observable } from 'rxjs';
 import {
   BehaviorSubject,
   from,
@@ -8,7 +9,6 @@ import {
   merge,
   mergeMap,
   NEVER,
-  Observable,
   of,
   tap,
   throwError,
@@ -16,7 +16,7 @@ import {
 import { map, switchMap, take } from 'rxjs/operators';
 
 import { Y_CONFIG } from '../../tokens/y-config';
-import { YConfig } from '../../types/y-config';
+import type { YConfig } from '../../types/y-config';
 import { exitZone } from '../../utils/zone/zone';
 
 /**

--- a/libs/angular-yandex-maps-v3/src/lib/tokens/y-config.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/tokens/y-config.ts
@@ -1,7 +1,7 @@
 import { InjectionToken, makeEnvironmentProviders } from '@angular/core';
-import { Observable } from 'rxjs';
+import type { Observable } from 'rxjs';
 
-import { YConfig } from '../types/y-config';
+import type { YConfig } from '../types/y-config';
 
 /**
  * @internal

--- a/libs/angular-yandex-maps-v3/src/lib/types/complex-options.ts
+++ b/libs/angular-yandex-maps-v3/src/lib/types/complex-options.ts
@@ -1,4 +1,4 @@
-import { GenericEntity, GenericRootEntity } from '@yandex/ymaps3-types/imperative/Entities';
+import type { GenericEntity, GenericRootEntity } from '@yandex/ymaps3-types/imperative/Entities';
 
 /**
  * Typings do not export this type, but it's used it in many places.

--- a/libs/docsifier/src/main.ts
+++ b/libs/docsifier/src/main.ts
@@ -1,13 +1,13 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
-import { CompodocComponent } from './types/compodoc-component';
-import { CompodocDirective } from './types/compodoc-directive';
-import { CompodocInjectable } from './types/compodoc-injectable';
-import { CompodocInterface } from './types/compodoc-interface';
-import { CompodocTypealias } from './types/compodoc-typealias';
-import { CompodocVariable } from './types/compodoc-variable';
-import { CompodocDocumentation } from './types/compodocDocumentation';
+import type { CompodocComponent } from './types/compodoc-component';
+import type { CompodocDirective } from './types/compodoc-directive';
+import type { CompodocInjectable } from './types/compodoc-injectable';
+import type { CompodocInterface } from './types/compodoc-interface';
+import type { CompodocTypealias } from './types/compodoc-typealias';
+import type { CompodocVariable } from './types/compodoc-variable';
+import type { CompodocDocumentation } from './types/compodocDocumentation';
 import { copyFiles } from './utils/copy-files';
 import { createComponentMarkdown } from './utils/create-component-markdown';
 import { createInterfaceMarkdown } from './utils/create-interface-markdown';

--- a/libs/docsifier/src/types/compodoc-component.ts
+++ b/libs/docsifier/src/types/compodoc-component.ts
@@ -1,3 +1,3 @@
-import { CompodocDirective } from './compodoc-directive';
+import type { CompodocDirective } from './compodoc-directive';
 
 export type CompodocComponent = CompodocDirective;

--- a/libs/docsifier/src/types/compodoc-directive.ts
+++ b/libs/docsifier/src/types/compodoc-directive.ts
@@ -1,6 +1,6 @@
-import { CompodocEntity } from './compodoc-entity';
-import { CompodocInput } from './compodoc-input';
-import { CompodocOutput } from './compodoc-output';
+import type { CompodocEntity } from './compodoc-entity';
+import type { CompodocInput } from './compodoc-input';
+import type { CompodocOutput } from './compodoc-output';
 
 export interface CompodocDirective extends CompodocEntity {
   animations?: string[];

--- a/libs/docsifier/src/types/compodoc-injectable.ts
+++ b/libs/docsifier/src/types/compodoc-injectable.ts
@@ -1,4 +1,4 @@
-import { CompodocEntity } from './compodoc-entity';
+import type { CompodocEntity } from './compodoc-entity';
 
 export interface CompodocInjectable extends CompodocEntity {
   properties: [];

--- a/libs/docsifier/src/types/compodoc-input.ts
+++ b/libs/docsifier/src/types/compodoc-input.ts
@@ -1,4 +1,4 @@
-import { CompodocEntity } from './compodoc-entity';
+import type { CompodocEntity } from './compodoc-entity';
 
 export interface CompodocInput extends CompodocEntity {
   line: number;

--- a/libs/docsifier/src/types/compodoc-interface.ts
+++ b/libs/docsifier/src/types/compodoc-interface.ts
@@ -1,4 +1,4 @@
-import { CompodocEntity } from './compodoc-entity';
+import type { CompodocEntity } from './compodoc-entity';
 
 export interface CompodocInterface extends CompodocEntity {
   indexSignatures: unknown[];

--- a/libs/docsifier/src/types/compodoc-miscellaneous.ts
+++ b/libs/docsifier/src/types/compodoc-miscellaneous.ts
@@ -1,6 +1,6 @@
-import { CompodocEntity } from './compodoc-entity';
-import { CompodocTypealias } from './compodoc-typealias';
-import { CompodocVariable } from './compodoc-variable';
+import type { CompodocEntity } from './compodoc-entity';
+import type { CompodocTypealias } from './compodoc-typealias';
+import type { CompodocVariable } from './compodoc-variable';
 
 export interface CompodocMiscellaneous extends CompodocEntity {
   variables: CompodocVariable[];

--- a/libs/docsifier/src/types/compodoc-module.ts
+++ b/libs/docsifier/src/types/compodoc-module.ts
@@ -1,4 +1,4 @@
-import { CompodocEntity } from './compodoc-entity';
+import type { CompodocEntity } from './compodoc-entity';
 
 export interface CompodocModule extends CompodocEntity {
   bootstrap?: unknown[];

--- a/libs/docsifier/src/types/compodoc-output.ts
+++ b/libs/docsifier/src/types/compodoc-output.ts
@@ -1,4 +1,4 @@
-import { CompodocEntity } from './compodoc-entity';
+import type { CompodocEntity } from './compodoc-entity';
 
 export interface CompodocOutput extends CompodocEntity {
   defaultValue: string;

--- a/libs/docsifier/src/types/compodoc-typealias.ts
+++ b/libs/docsifier/src/types/compodoc-typealias.ts
@@ -1,3 +1,3 @@
-import { CompodocEntity } from './compodoc-entity';
+import type { CompodocEntity } from './compodoc-entity';
 
 export type CompodocTypealias = CompodocEntity;

--- a/libs/docsifier/src/types/compodoc-variable.ts
+++ b/libs/docsifier/src/types/compodoc-variable.ts
@@ -1,4 +1,4 @@
-import { CompodocEntity } from './compodoc-entity';
+import type { CompodocEntity } from './compodoc-entity';
 
 export interface CompodocVariable extends CompodocEntity {
   ctype: string;

--- a/libs/docsifier/src/types/compodocDocumentation.ts
+++ b/libs/docsifier/src/types/compodocDocumentation.ts
@@ -1,9 +1,9 @@
-import { CompodocComponent } from './compodoc-component';
-import { CompodocDirective } from './compodoc-directive';
-import { CompodocFunction } from './compodoc-function';
-import { CompodocInjectable } from './compodoc-injectable';
-import { CompodocInterface } from './compodoc-interface';
-import { CompodocMiscellaneous } from './compodoc-miscellaneous';
+import type { CompodocComponent } from './compodoc-component';
+import type { CompodocDirective } from './compodoc-directive';
+import type { CompodocFunction } from './compodoc-function';
+import type { CompodocInjectable } from './compodoc-injectable';
+import type { CompodocInterface } from './compodoc-interface';
+import type { CompodocMiscellaneous } from './compodoc-miscellaneous';
 
 export interface CompodocDocumentation {
   classes: unknown[];

--- a/libs/docsifier/src/utils/create-component-markdown.ts
+++ b/libs/docsifier/src/utils/create-component-markdown.ts
@@ -3,10 +3,10 @@ import { markdownTable } from 'markdown-table';
 import * as path from 'path';
 import dedent from 'ts-dedent';
 
-import { CompodocComponent } from '../types/compodoc-component';
-import { CompodocDirective } from '../types/compodoc-directive';
-import { CompodocInput } from '../types/compodoc-input';
-import { CompodocOutput } from '../types/compodoc-output';
+import type { CompodocComponent } from '../types/compodoc-component';
+import type { CompodocDirective } from '../types/compodoc-directive';
+import type { CompodocInput } from '../types/compodoc-input';
+import type { CompodocOutput } from '../types/compodoc-output';
 import { formatDescription } from './format-description';
 
 /**

--- a/libs/docsifier/src/utils/create-interface-markdown.ts
+++ b/libs/docsifier/src/utils/create-interface-markdown.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import dedent from 'ts-dedent';
 
-import { CompodocInterface } from '../types/compodoc-interface';
+import type { CompodocInterface } from '../types/compodoc-interface';
 import { formatDescription } from './format-description';
 
 /**

--- a/libs/docsifier/src/utils/create-service-markdown.ts
+++ b/libs/docsifier/src/utils/create-service-markdown.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import dedent from 'ts-dedent';
 
-import { CompodocInjectable } from '../types/compodoc-injectable';
+import type { CompodocInjectable } from '../types/compodoc-injectable';
 import { formatDescription } from './format-description';
 
 /**

--- a/libs/docsifier/src/utils/create-sidebar-markdown.ts
+++ b/libs/docsifier/src/utils/create-sidebar-markdown.ts
@@ -2,8 +2,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import dedent from 'ts-dedent';
 
-import { CompodocEntity } from '../types/compodoc-entity';
-import { CompodocDocumentation } from '../types/compodocDocumentation';
+import type { CompodocEntity } from '../types/compodoc-entity';
+import type { CompodocDocumentation } from '../types/compodocDocumentation';
 
 const sourceCodeDirectory = 'lib';
 

--- a/libs/docsifier/src/utils/create-typealias-markdown.ts
+++ b/libs/docsifier/src/utils/create-typealias-markdown.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import dedent from 'ts-dedent';
 
-import { CompodocTypealias } from '../types/compodoc-typealias';
+import type { CompodocTypealias } from '../types/compodoc-typealias';
 import { formatDescription } from './format-description';
 
 /**

--- a/libs/docsifier/src/utils/create-variables-markdown.ts
+++ b/libs/docsifier/src/utils/create-variables-markdown.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import dedent from 'ts-dedent';
 
-import { CompodocVariable } from '../types/compodoc-variable';
+import type { CompodocVariable } from '../types/compodoc-variable';
 import { formatDescription } from './format-description';
 
 /**

--- a/libs/docsifier/src/utils/parse-documentation.ts
+++ b/libs/docsifier/src/utils/parse-documentation.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 
-import { CompodocDocumentation } from '../types/compodocDocumentation';
+import type { CompodocDocumentation } from '../types/compodocDocumentation';
 
 /**
  * Parses a JSON compodoc documentation.


### PR DESCRIPTION
## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring
- [ ] Build or CI related changes
- [ ] Documentation content changes

## Which library does this PR affect?

- [x] angular-yandex-maps-v2
- [x] angular-yandex-maps-v3

## What is the current behavior?

To support Angular 21 we have to change how modules are resolved and transpiled. It affects the final code, which Jest tries to execute and fails.

## What is the new behavior?

Replace `import` with `import type` for types.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
